### PR TITLE
Drop ghc-8.5.6 and ghc-8.8.4

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,8 +77,8 @@
              let compilers = builtins.removeAttrs pkgs.haskell-nix.compiler
                # Exclude old versions of GHC to speed up `nix flake check`
                [ "ghc844"
-                 "ghc861" "ghc862" "ghc863" "ghc864"
-                 "ghc881" "ghc882" "ghc883"
+                 "ghc861" "ghc862" "ghc863" "ghc864" "ghc865"
+                 "ghc881" "ghc882" "ghc883" "ghc884"
                  "ghc8101" "ghc8102" "ghc8103" "ghc8104" "ghc8105" "ghc8106" "ghc810420210212"
                  "ghc901"
                  "ghc921" "ghc922" "ghc923"];


### PR DESCRIPTION
We don't use those anymore