### PR TITLE
Export a colored PS1 prompt in the shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -99,6 +99,8 @@
              in (__mapAttrs (compiler-nix-name: compiler:
               pkgs.mkShell {
                 shellHook = with pkgs; ''
+                  export PS1="\[\033[01;33m\][\w]$\[\033[00m\] "
+
                   ${figlet}/bin/figlet -f rectangles 'IOG Haskell Shell'
                   function cabal() {
                     case "$1" in 


### PR DESCRIPTION
This shell has been tested on https://github.com/Quviq/quickcheck-contractmodel and it works (even on WLS2).
The developers are asking for a shell prompt, so that they know they are inside the shell.
This prompt simply prints the current directory in yellow