### PR TITLE
Update `haskell/nix-shell/action.yml` from `ghc924`

### DIFF
--- a/haskell/nix-shell/action.yml
+++ b/haskell/nix-shell/action.yml
@@ -4,7 +4,7 @@ inputs:
   compiler:
     description: 'compiler name to use, e.g. ghc8107, ghc924, ...'
     required: true
-    default: "ghc924"
+    default: "ghc925"
 
 runs:
   using: "composite"


### PR DESCRIPTION
Is this up to date? I think `ghc924` is part of the GHC version the shell opt out https://github.com/input-output-hk/devx/blob/main/flake.nix#L103 as described here https://github.com/input-output-hk/devx/issues/23