### PR TITLE
Run tests with wine by default

### DIFF
--- a/cross-windows.nix
+++ b/cross-windows.nix
@@ -131,6 +131,7 @@ pkgs.pkgsBuildBuild.mkShell ({
     "--with-ghc=x86_64-w64-mingw32-ghc"
     "--with-ghc-pkg=x86_64-w64-mingw32-ghc-pkg"
     "--with-hsc2hs=x86_64-w64-mingw32-hsc2hs"
+    # Test wrapper that will run cabal tests with wine (from wine-test-wrapper)
     "--test-wrapper=x86_64-w64-mingw32-test-wrapper"
     # ensure that the linker knows we want a static build product
     # "--enable-executable-static"

--- a/cross-windows.nix
+++ b/cross-windows.nix
@@ -104,6 +104,9 @@ let tool-version-map = import ./tool-map.nix;
           find "$p" -iname '*.dll' -exec ln -sf {} $DLLS \;
           find "$p" -iname '*.dll.a' -exec ln -sf {} $DLLS \;
         done
+        # Some DLLs have a `lib` prefix but we attempt to load them without the prefix.
+        # This was a problem for `double-conversion` package when used in TH code.
+        # Creating links from the `X.dll` to `libX.dll` works around this issue.
         (
         cd $DLLS
         for l in lib*.dll; do

--- a/cross-windows.nix
+++ b/cross-windows.nix
@@ -131,7 +131,8 @@ pkgs.pkgsBuildBuild.mkShell ({
     "--with-ghc=x86_64-w64-mingw32-ghc"
     "--with-ghc-pkg=x86_64-w64-mingw32-ghc-pkg"
     "--with-hsc2hs=x86_64-w64-mingw32-hsc2hs"
-    # Test wrapper that will run cabal tests with wine (from wine-test-wrapper)
+    # We use the test-wrapper option here so that tests are executed through
+    # WINE, as we can't run windows test natively.
     "--test-wrapper=x86_64-w64-mingw32-test-wrapper"
     # ensure that the linker knows we want a static build product
     # "--enable-executable-static"


### PR DESCRIPTION
When cross compiling for windows use set the cabal flag `--test-wrapper` to point at a script that runs the test in wine.