### PR TITLE
Update dynamic.nix

### DIFF
--- a/dynamic.nix
+++ b/dynamic.nix
@@ -86,6 +86,8 @@ pkgs.mkShell {
     ++ pkgs.lib.optional (withHlint && (compiler-not-in (["ghc961"] ++ pkgs.lib.optional (pkgs.stdenv.hostPlatform.isDarwin && pkgs.stdenv.hostPlatform.isAarch64) "ghc902") "HLint")) (tool "hlint")
     ++ pkgs.lib.optional withIOG
         (with pkgs; [ cddl cbor-diag ]
-        ++ map pkgs.lib.getDev (with pkgs; [ libblst libsodium-vrf secp256k1 R_4_1_3]))
+        # R for plutus
+        # postgresql for db-sync
+        ++ map pkgs.lib.getDev (with pkgs; [ libblst libsodium-vrf secp256k1 R_4_1_3 postgresql]))
     ;
 }

--- a/static.nix
+++ b/static.nix
@@ -124,7 +124,8 @@ pkgs.mkShell (rec {
         libblst
         libsodium-vrf
         secp256k1
-        #R_4_1_3
+        #R_4_1_3      # for plutus
+        postgresql    # for db-sync
     ]);
 
     # these are _native_ libs, we need to drive the compilation environment


### PR DESCRIPTION
This adds `postgresql` to the dependencies in the `-iog` shell. Necessary to build `cardano-db-sync`.

I'm a bit concerned that this might become an issue on all platforms, and the size increase of the closure :-/

- [ ] verify this works across all platforms. (e.g. we can enter the shell)
- [ ] can we somehow look at the size of the closures and how much this increases all?