### PR TITLE
Avoid building in GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
           # fixed output of the derivation is already in the `/nix/store` and will
           # not try to fetch it using the platform we do not have a builder for.
           if [[ "${{ matrix.platform }}" != "x86_64-linux" && "${{ matrix.target-platform }}" = "-js" ]]; then
-            nix build ".#hydraJobs.x86_64-linux.${{ matrix.compiler-nix-name }}-js-minimal" --show-trace
+            nix build --builders "" --max-jobs 0 ".#hydraJobs.x86_64-linux.${{ matrix.compiler-nix-name }}-js-minimal" --show-trace
           fi
       - name: Compute and upload closure and developer environment to ghcr.io
         env:

--- a/extra/ghcr-upload.sh
+++ b/extra/ghcr-upload.sh
@@ -2,6 +2,6 @@
 #! nix-shell -i bash -p zstd -p oras
 set -euox pipefail
 
-nix build ".#hydraJobs.${DEV_SHELL}" --show-trace
+nix build --builders "" --max-jobs 0 ".#hydraJobs.${DEV_SHELL}" --show-trace
 nix-store --export $(nix-store -qR result) | zstd -z8T8 >${DEV_SHELL}
 oras push ghcr.io/input-output-hk/devx:${DEV_SHELL} ${DEV_SHELL}

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
                   "ghc945"
                  ];
                  windows-compilers = pkgs:
-                   pkgs.lib.optionalAttrs (__elem system ["x86_64-linux" "x86_64-darwin"])
+                   pkgs.lib.optionalAttrs (__elem system ["x86_64-linux"])
                    (builtins.removeAttrs (compilers pkgs)
                      [
                      ]);


### PR DESCRIPTION
GHA should be able to download the required files from the nix cache populated by hydra.  If it cannot DL what it needs, it is better to have it fail instead of wasting resources trying a build that will probably eventually run out of disk space anyway.