### PR TITLE
Revert "Avoid building in GHA"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
           # fixed output of the derivation is already in the `/nix/store` and will
           # not try to fetch it using the platform we do not have a builder for.
           if [[ "${{ matrix.platform }}" != "x86_64-linux" && "${{ matrix.target-platform }}" = "-js" ]]; then
-            nix build --builders "" --max-jobs 0 ".#hydraJobs.x86_64-linux.${{ matrix.compiler-nix-name }}-js-minimal" --show-trace
+            nix build ".#hydraJobs.x86_64-linux.${{ matrix.compiler-nix-name }}-js-minimal" --show-trace
           fi
       - name: Compute and upload closure and developer environment to ghcr.io
         env:

--- a/extra/ghcr-upload.sh
+++ b/extra/ghcr-upload.sh
@@ -2,6 +2,6 @@
 #! nix-shell -i bash -p zstd -p oras
 set -euox pipefail
 
-nix build --builders "" --max-jobs 0 ".#hydraJobs.${DEV_SHELL}" --show-trace
+nix build ".#hydraJobs.${DEV_SHELL}" --show-trace
 nix-store --export $(nix-store -qR result) | zstd -z8T8 >${DEV_SHELL}
 oras push ghcr.io/input-output-hk/devx:${DEV_SHELL} ${DEV_SHELL}


### PR DESCRIPTION
This reverts commit 43d7fb43e58a8bc4e35e72f00786633e3387c4d8.

It turns out that we need to build the `plan-nix` derivations as they are not cached.