### PR TITLE
Add `packages: write` permission to GA that build Codespace docker images

### DIFF
--- a/.github/workflows/codespace.yml
+++ b/.github/workflows/codespace.yml
@@ -13,6 +13,8 @@ env:
 
 jobs:
   build_and_push:
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This as been tested to be working as expected [in this fork](https://github.com/yvan-sraka/devx/pkgs/container/devx-devcontainer)! I also had to [configure the default `GITHUB_TOKEN` permissions](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-the-default-github_token-permissions) of the repository.