### PR TITLE
Add `aarch64-linux` to GitHub Codespace Action to support macOS M1/M2 VSCode DevContainers

### DIFF
--- a/.github/workflows/codespace.yml
+++ b/.github/workflows/codespace.yml
@@ -26,7 +26,7 @@ jobs:
     # and the GHC version (currently `ghc8107` and `ghc962`).
     strategy:
       matrix:
-        platform: ['x86_64-linux']
+        platform: ['x86_64-linux', 'aarch64-linux']
         target-platform: ['', '-windows', '-js']
         compiler-nix-name: ['ghc8107','ghc962']
         minimal: [false]
@@ -47,7 +47,7 @@ jobs:
       with:
         context: .
         push: true
-        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.compiler-nix-name }}${{ matrix.target-platform }}-iog
+        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.platform }}.${{ matrix.compiler-nix-name }}${{ matrix.target-platform }}-iog
         build-args: |
           platform=${{ matrix.platform }}
           target-platform=${{ matrix.target-platform }}


### PR DESCRIPTION
I'm not sure of that one, since the GA will be run on an `x86_64` machine, right?