### PR TITLE
Fix Codespace image generation (always empty Dockerfile `ARG`…)

### DIFF
--- a/.github/workflows/codespace.yml
+++ b/.github/workflows/codespace.yml
@@ -1,4 +1,4 @@
-name: Build and push Docker image
+name: Build and push GitHub Codespace images
 
 on:
   push:
@@ -49,8 +49,8 @@ jobs:
         push: true
         tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.compiler-nix-name }}${{ matrix.target-platform }}-iog
         build-args: |
-          platform=${{ matrix.platform }}
-          target-platform=${{ matrix.target-platform }}
-          compiler-nix-name=${{ matrix.compiler-nix-name }}
-          minimal=${{ matrix.minimal }}
-          iog=${{ matrix.iog }}
+          PLATFORM=${{ matrix.platform }}
+          TARGET_PLATFORM=${{ matrix.target-platform }}
+          COMPILER_NIX_NAME=${{ matrix.compiler-nix-name }}
+          MINIMAL=${{ matrix.minimal }}
+          IOG=${{ matrix.iog }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
-ARG platform=x86_64-linux
-ARG target_platform=""
-ARG compiler_nix_name=ghc961
-ARG minimal=true
-ARG iog=false
-
 FROM ubuntu:rolling
 WORKDIR /workspaces
+
+ARG PLATFORM="x86_64-linux"
+ARG TARGET_PLATFORM=""
+ARG COMPILER_NIX_NAME="ghc961"
+ARG MINIMAL="true"
+ARG IOG="false"
 
 RUN apt-get update \
  && yes | apt-get install curl git jq nix zstd \
  && curl -L https://raw.githubusercontent.com/input-output-hk/actions/latest/devx/support/fetch-docker.sh -o fetch-docker.sh \
  && chmod +x fetch-docker.sh \
  && SUFFIX='' \
- && if [ "$minimal" = true ]; then SUFFIX="${SUFFIX}-minimal"; fi \
- && if [ "$iog" = true ]; then SUFFIX="${SUFFIX}-iog"; fi \
- && ./fetch-docker.sh input-output-hk/devx $platform.$compiler_nix_name$target_platform$SUFFIX-env | zstd -d | nix-store --import | tee store-paths.txt \
+ && if [ "$MINIMAL" = "true" ]; then SUFFIX="${SUFFIX}-minimal"; fi \
+ && if [ "$IOG" = "true" ]; then SUFFIX="${SUFFIX}-iog"; fi \
+ && ./fetch-docker.sh input-output-hk/devx $PLATFORM.$COMPILER_NIX_NAME$TARGET_PLATFORM${SUFFIX}-env | zstd -d | nix-store --import | tee store-paths.txt \
  && yes | apt-get remove curl jq nix zstd \
  && yes | apt-get autoremove \
  && yes | apt-get autoclean


### PR DESCRIPTION
This is apparently the default behavior chosen by Docker when `ARG` are defined before `FROM` … and indeed Docker don't bother you with any warning :)