### PR TITLE
Check while caling `ghcr-upload.sh` that closure contains `devx` shell rc derivation

### DIFF
--- a/extra/ghcr-upload.sh
+++ b/extra/ghcr-upload.sh
@@ -3,5 +3,6 @@
 set -euox pipefail
 
 nix build ".#hydraJobs.${DEV_SHELL}" --show-trace
-nix-store --export $(nix-store -qR result) | zstd -z8T8 >${DEV_SHELL}
+nix-store --export $(nix-store -qR result) | zstd -z8T8 >${DEV_SHELL} | tee store-paths.txt
+if [[ ! $(tail -n 1 store-paths.txt) =~ "devx" ]]; then exit 1; fi
 oras push ghcr.io/input-output-hk/devx:${DEV_SHELL} ${DEV_SHELL}


### PR DESCRIPTION
The motivation is to detect the faulty closures by failing in CI, rather than silently uploading them to ghcr.io