### PR TITLE
Update HLS to version 2.0

### DIFF
--- a/tool-map.nix
+++ b/tool-map.nix
@@ -1,5 +1,5 @@
 # see https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html
-# so we assume "latest" for all hls. 
+# so we assume "latest" for all hls.
 # for hlint however, we need hlint-3.3 for ghc-8.10.7.
 let fixed-versions = { "hlint" = { "ghc8107" = { version = "3.3"; }; }; }; in
 compiler-nix-name: tool: {
@@ -8,7 +8,7 @@ compiler-nix-name: tool: {
   # HLS release. Therefore we rely on the HLS upstream repository to provide the proper configuration information.
   haskell-language-server = {pkgs, ...}: rec {
       # Use the github source of HLS that is tested with haskell.nix CI
-      src = pkgs.haskell-nix.sources."hls-1.10";
+      src = pkgs.haskell-nix.sources."hls-2.0";
       # `tool` normally ignores the `cabal.project` (if there is one in the hackage source).
       # We need to use the github one (since it has settings to make hls build).
       cabalProject = __readFile (src + "/cabal.project");


### PR DESCRIPTION
```
% nix develop ".#ghc962"
trace: No HLint. Not yet compatible with ghc962
                                                                     
 _____ _____ _____    _____         _       _ _    _____ _       _ _ 
|     |     |   __|  |  |  |___ ___| |_ ___| | |  |   __| |_ ___| | |
|-   -|  |  |  |  |  |     | .'|_ -| '_| -_| | |  |__   |   | -_| | |
|_____|_____|_____|  |__|__|__,|___|_,_|___|_|_|  |_____|_|_|___|_|_|
                                                                     
Revision (input-output-hk/devx): 63135bc983b8000fcd267843740f3cdad7bf8d75.
CABAL_DIR set to /Users/yvan/.cabal-devx
[~/IOHK/devx]$ haskell-language-server --version
2023-08-28T09:40:27.450883Z | Info | No log file specified; using stderr.
haskell-language-server version: 2.0.0.0 (GHC: 9.6.2) (PATH: /nix/store/jfbsphs6bqq52cs185ynxmzc5h55prb1-haskell-language-server-exe-haskell-language-server-2.0.0.0/bin/haskell-language-server)
```

It currently provides version `2.0.0.0` and `2.0.0.1` is the one marked as _recommended_ by `ghcup`, but [`nix flake update`](https://github.com/input-output-hk/devx/pull/94) solve that :)