### PR TITLE
Expose `CABAL_PROJECT_LOCAL_TEMPLATE` as a `/nix/store/` file

### DIFF
--- a/cross-js.nix
+++ b/cross-js.nix
@@ -35,6 +35,7 @@ let tool-version-map = import ./tool-map.nix;
           ${compiler}/bin/${compiler.targetPrefix}hsc2hs --cross-compile "$@"
         '';
     };
+    quirks = (import ./quirks.nix { inherit pkgs; });
 in
 pkgs.mkShell ({
     # Note [cabal override]:
@@ -58,13 +59,7 @@ pkgs.mkShell ({
     ];
     # hardeningDisable = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isMusl [ "format" "pie" ];
 
-    CABAL_PROJECT_LOCAL_TEMPLATE = with pkgs; ''
-    package digest
-    constraints:
-    HsOpenSSL +use-pkg-config,
-    zlib +pkg-config
-    pcre-lite +pkg-config
-    '';
+    inherit (quirks) CABAL_PROJECT_LOCAL_TEMPLATE;
 
     shellHook = with pkgs; ''
         export PS1="\[\033[01;33m\][\w]$\[\033[00m\] "
@@ -73,7 +68,7 @@ pkgs.mkShell ({
         echo "Revision (input-output-hk/devx): ${if self ? rev then self.rev else "unknown/dirty checkout"}."
         export CABAL_DIR=$HOME/.cabal-js
         echo "CABAL_DIR set to $CABAL_DIR"
-    '';
+    '' + quirks.shellHook;
     buildInputs = [];
 
     nativeBuildInputs = [ wrapped-hsc2hs wrapped-cabal compiler ] ++ (with pkgs; [

--- a/cross-windows.nix
+++ b/cross-windows.nix
@@ -115,7 +115,7 @@ let tool-version-map = import ./tool-map.nix;
         )
         WINEPATH=$DLLS WINEDLLOVERRIDES="winemac.drv=d" WINEDEBUG=warn-all,fixme-all,-menubuilder,-mscoree,-ole,-secur32,-winediag WINEPREFIX=$TMP ${pkgs.pkgsBuildBuild.winePackages.minimal}/bin/wine64 "$@"
       '';
-
+    quirks = (import ./quirks.nix { inherit pkgs; });
 in
 pkgs.pkgsBuildBuild.mkShell ({
     # Note [cabal override]:
@@ -141,12 +141,7 @@ pkgs.pkgsBuildBuild.mkShell ({
     # "--enable-executable-static"
     ];
 
-    CABAL_PROJECT_LOCAL_TEMPLATE = ''
-    constraints:
-      HsOpenSSL +use-pkg-config,
-      zlib +pkg-config,
-      pcre-lite +pkg-config
-    '';
+    inherit (quirks) CABAL_PROJECT_LOCAL_TEMPLATE;
 
     shellHook = with pkgs; ''
       export PS1="\[\033[01;33m\][\w]$\[\033[00m\] "
@@ -155,7 +150,7 @@ pkgs.pkgsBuildBuild.mkShell ({
       echo "Revision (input-output-hk/devx): ${if self ? rev then self.rev else "unknown/dirty checkout"}."
       export CABAL_DIR=$HOME/.cabal-windows
       echo "CABAL_DIR set to $CABAL_DIR"
-    '';
+    '' + quirks.shellHook;
     buildInputs = [];
 
     nativeBuildInputs = [ wrapped-ghc wrapped-hsc2hs wrapped-cabal wine-test-wrapper compiler ] ++ (with pkgs; [

--- a/quirks.nix
+++ b/quirks.nix
@@ -1,0 +1,22 @@
+{ pkgs, static ? false }: rec {
+  CABAL_PROJECT_LOCAL_TEMPLATE = with pkgs; ''
+  package digest
+  ${if static then "extra-lib-dirs: ${zlib}/lib ${pcre}/lib" else ""}
+  constraints:
+    HsOpenSSL +use-pkg-config,
+    zlib +pkg-config,
+    pcre-lite +pkg-config
+  '';
+  template = pkgs.writeTextFile {
+    name = "cabal.project.local";
+    text = CABAL_PROJECT_LOCAL_TEMPLATE;
+  };
+  shellHook = ''
+    echo "Quirks:"
+    echo -e "\tif you have the zlib, HsOpenSSL, or digest package in your dependency tree, please make sure to"
+    echo -e "\tcat ${template} >> cabal.project.local"
+    function patchProjectLocal() {
+      cat ${template} >> "$1"
+    }
+  '';
+}


### PR DESCRIPTION
```
% nix develop ".#ghc962-static-minimal"
                                                                     
 _____ _____ _____    _____         _       _ _    _____ _       _ _ 
|     |     |   __|  |  |  |___ ___| |_ ___| | |  |   __| |_ ___| | |
|-   -|  |  |  |  |  |     | .'|_ -| '_| -_| | |  |__   |   | -_| | |
|_____|_____|_____|  |__|__|__,|___|_,_|___|_|_|  |_____|_|_|___|_|_|
                                                                     
             _        _   _             _ _ _   _                   
_/\____   __| |_ __ _| |_(_)__   ___ __| (_) |_(_)___ _ _    ____/\_
>  <___| (_-<  _/ _` |  _| / _| / -_) _` | |  _| / _ \ ' \  |___>  <
 \/|___| /__/\__\__,_|\__|_\__| \___\__,_|_|\__|_\___/_||_| |___|\/ 
                                                                    
Revision (input-output-hk/devx): 9fb95ac431622597fb663d5c00525bb42845bc51.
NOTE (macos): you can use fixup-nix-deps FILE, to fix iconv, ffi, and zlib dependencies that point to the /nix/store
CABAL_DIR set to /Users/yvan/.cabal-static
DYLD_LIBRARY_PATH set to /nix/store/jc495w1m1z7ph6hhad875kj66q3mggr1-openssl-3.0.8/lib
Quirks:
        if you have the zlib, HsOpenSSL, or digest package in your dependency tree, please make sure to
        cat /nix/store/4yrk2l4kp94xyh8mb9hsa9mx84sgifmy-cabal.project.local >> cabal.project.local
```
```
[~/IOHK/devx]$ cat /nix/store/4yrk2l4kp94xyh8mb9hsa9mx84sgifmy-cabal.project.local
package digest
  extra-lib-dirs: /nix/store/7n13ddp1m3340ls4x3zx9qkjhqidi08x-zlib-1.2.13/lib /nix/store/zb8jg7p56k0071svhqa3hqgl40d1h93m-pcre-8.45-bin/lib
constraints:
  HsOpenSSL +use-pkg-config,
  zlib +pkg-config,
  pcre-lite +pkg-config
```