### PR TITLE
Wait for x86_64-linux.required

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   wait-for-hydra-eval:
     env:
-      HYDRA_JOB: ci/eval
+      HYDRA_JOB: x86_64-linux.required
       GH_TOKEN: ${{ github.token }}
     name: "Wait for hydra status"
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is better than ci/eval which is only the eval step.