### PR TITLE
Fix #124: cabal update with CHaP fails inside Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,18 @@ ARG COMPILER_NIX_NAME="ghc961"
 ARG MINIMAL="true"
 ARG IOG="false"
 
-RUN apt-get update \
- && yes | apt-get install curl git jq nix zstd \
+RUN DEBIAN_FRONTEND=noninteractive \
+ && apt-get update \
+ && apt-get -y install curl git jq nix zstd \
  && curl -L https://raw.githubusercontent.com/input-output-hk/actions/latest/devx/support/fetch-docker.sh -o fetch-docker.sh \
  && chmod +x fetch-docker.sh \
  && SUFFIX='' \
  && if [ "$MINIMAL" = "true" ]; then SUFFIX="${SUFFIX}-minimal"; fi \
  && if [ "$IOG" = "true" ]; then SUFFIX="${SUFFIX}-iog"; fi \
  && ./fetch-docker.sh input-output-hk/devx $PLATFORM.$COMPILER_NIX_NAME$TARGET_PLATFORM${SUFFIX}-env | zstd -d | nix-store --import | tee store-paths.txt \
- && yes | apt-get remove curl jq nix zstd \
- && yes | apt-get autoremove \
- && yes | apt-get autoclean
+ && apt-get -y remove curl git jq nix zstd \
+ && apt-get -y autoremove \
+ && apt-get -y autoclean
 
 # `tail -n 2 X | head -n 1` seems a bit fragile way to get `ghc8107-iog-env.sh` derivation path ...
 RUN echo "source $(tail -n 2 store-paths.txt | head -n 1)" >> $HOME/.bashrc


### PR DESCRIPTION
... seems like `curl` should be available in DevContainer to use `chap`, otherwise:
```
[/workspaces/cardano-base]$ which curl
[/workspaces/cardano-base]$ cabal update
Warning: Caught exception during _mirrors lookup:user error (res_query(3)
failed)
Warning: No mirrors found for https://chap.intersectmbo.org/
user error (https not supported)
```
@andreabedini thoughts on that?