### PR TITLE
Improve GitHub Codespace First-Launch Time by Preloading `.cache`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,23 +3,54 @@ WORKDIR /workspaces
 
 ARG PLATFORM="x86_64-linux"
 ARG TARGET_PLATFORM=""
-ARG COMPILER_NIX_NAME="ghc961"
-ARG MINIMAL="true"
-ARG IOG="false"
+ARG COMPILER_NIX_NAME="ghc96"
+ARG MINIMAL="false"
+ARG IOG="true"
 
 RUN DEBIAN_FRONTEND=noninteractive \
  && apt-get update \
- && apt-get -y install curl git jq nix zstd \
+ && apt-get -y install curl gh git grep jq nix rsync zstd \
  && curl -L https://raw.githubusercontent.com/input-output-hk/actions/latest/devx/support/fetch-docker.sh -o fetch-docker.sh \
  && chmod +x fetch-docker.sh \
  && SUFFIX='' \
  && if [ "$MINIMAL" = "true" ]; then SUFFIX="${SUFFIX}-minimal"; fi \
  && if [ "$IOG" = "true" ]; then SUFFIX="${SUFFIX}-iog"; fi \
  && if [ "$IOG_FULL" = "true" ]; then SUFFIX="${SUFFIX}-iog-full"; fi \
- && ./fetch-docker.sh input-output-hk/devx $PLATFORM.$COMPILER_NIX_NAME$TARGET_PLATFORM${SUFFIX}-env | zstd -d | nix-store --import | tee store-paths.txt \
- && apt-get -y remove curl git jq nix zstd \
- && apt-get -y autoremove \
- && apt-get -y autoclean
+ && ./fetch-docker.sh input-output-hk/devx $PLATFORM.$COMPILER_NIX_NAME$TARGET_PLATFORM${SUFFIX}-env | zstd -d | nix-store --import | tee store-paths.txt
 
-# `tail -n 2 X | head -n 1` seems a bit fragile way to get `ghc8107-iog-env.sh` derivation path ...
-RUN echo "source $(tail -n 2 store-paths.txt | head -n 1)" >> $HOME/.bashrc
+RUN cat <<EOF >> $HOME/.bashrc
+source $(grep -m 1 -e '-env.sh$' store-paths.txt)
+EOF
+
+# This enforce those settings in DevContainer whatever "Settings Sync" user preferences ...
+RUN mkdir -p $HOME/.vscode-server/data/Machine/ \
+ && cat <<EOF >> $HOME/.vscode-server/data/Machine/settings.json
+{ "haskell.manageHLS": "PATH" }
+EOF
+
+# FIXME: Consider moving this script into a Nix `writeShellApplication` trivial builder within the closure ...
+# ... but that means I should figure it out how to pass to it $COMPILER_NIX_NAME as input?
+RUN mkdir -p /usr/local/bin/ \
+ && cat <<EOF >> /usr/local/bin/post-create-command
+#!/usr/bin/env bash
+
+PROJECT_DIR=\$(find /workspaces/ -mindepth 1 -maxdepth 1 -type d)
+if [ -n "\$PROJECT_DIR" ]; then
+    pushd \$PROJECT_DIR > /dev/null
+    # GitHub Codespaces should have \$GH_TOKEN already set.
+    if [ -n "\$GH_TOKEN" ]; then
+        COMMIT_HASH=\$(git rev-parse HEAD)
+        echo "Attempting to download HLS cache from GitHub Artifact (cache-\$COMMIT_HASH-$COMPILER_NIX_NAME) for faster first launch ..."
+        gh run download -D .download -n "cache-\$COMMIT_HASH-$COMPILER_NIX_NAME"
+        rsync -a .download/work/cardano-base/cardano-base/dist-newstyle .
+        rm -r .download
+    else
+        echo "\\\$GH_TOKEN is not set. Skipping HLS cache download."
+    fi
+    # HLS error (Couldn't load cradle for ghc libdir) if `cabal update` has never been run in project using cardano-haskell-packages ...
+    echo "Running `cabal update` ..."
+    bash -c "cabal update"
+    popd > /dev/null
+fi
+EOF
+RUN chmod +x /usr/local/bin/post-create-command

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Refer to [`direnv` and `devx`](./docs/direnv.md) guide for more information.
 To make this developer shell available in VSCode DevContainer or GitHub CodeSpace, simply add a file named `.devcontainer/devcontainer.json` with the following content:
 ```json
 {
-   "image":"ghcr.io/input-output-hk/devx-devcontainer:x86_64-linux.ghc810-iog",
+   "image":"ghcr.io/input-output-hk/devx-devcontainer:x86_64-linux.ghc96-iog",
+   "postCreateCommand": "post-create-command",
    "customizations":{
       "vscode":{
          "extensions":[


### PR DESCRIPTION
Updates the `Dockerfile` used to create GitHub Codespace images to now preload the `$HOME/.cache` folder with artifacts from the corresponding repository's GitHub Actions. This aims to speed-up HLS startup in a fresh GitHub Codespace by leveraging previously built artifacts.

It's important to note that the cache download occurs when spawning a terminal in the Codespace, not during the image build process. The rationale behind this approach is to avoid building a unique Codespace image for each repository and to keep these images generic.

Additionally, if the artifacts are not found in the cache, the script will fail silently (considering adding a warning) since caching build artifacts is an optional, opt-in feature per repository. Also, note that caching is based on a "per commit" basis by default, but this could be extended to other scenarios, such as "per branch" caching, even though the cached artifacts are expected to weight only a few megabytes.

Finally, I've started experimenting with a caching GitHub Action in the `cardano-base` repository in [this PR](https://github.com/IntersectMBO/cardano-base/pull/465).