### PR TITLE
Fix #132: add support for GHC 9.6.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,6 @@ jobs:
           - ghc92
           - ghc96
           - ghc98
-          - ghc99
         target-platform:
           - ""
           - "-static"

--- a/cross-js.nix
+++ b/cross-js.nix
@@ -95,7 +95,7 @@ pkgs.mkShell ({
     ++ pkgs.lib.optional withIOG
         (with pkgs; [ cddl cbor-diag ]
         ++ map pkgs.lib.getDev (with pkgs; [
-            libblst libsodium-vrf secp256k1 #R_4_1_3
+            libblst libsodium-vrf secp256k1
         ]))
     ;
 })

--- a/cross-js.nix
+++ b/cross-js.nix
@@ -87,7 +87,8 @@ pkgs.mkShell ({
         stdenv.cc.cc.lib ]) ++ (with pkgs.buildPackages; [
     ])
     ++ pkgs.lib.optional (withHLS && (compiler-not-in (
-         pkgs.lib.optional (builtins.compareVersions compiler.version "9.9" >= 0) compiler-nix-name
+         # it appears we can't get HLS build with 9.8 yet.
+         pkgs.lib.optional (builtins.compareVersions compiler.version "9.7" >= 0) compiler-nix-name
       ++ pkgs.lib.optional (pkgs.stdenv.hostPlatform.isDarwin && pkgs.stdenv.hostPlatform.isAarch64) "ghc902") "Haskell Language Server")) (tool "haskell-language-server")
     ++ pkgs.lib.optional (withHlint && (compiler-not-in (
          pkgs.lib.optional (builtins.compareVersions compiler.version "9.8" >= 0) compiler-nix-name

--- a/cross-windows.nix
+++ b/cross-windows.nix
@@ -182,7 +182,7 @@ pkgs.pkgsBuildBuild.mkShell ({
     ++ pkgs.lib.optional withIOG
         (with pkgs.pkgsBuildBuild; [ cddl cbor-diag ]
         ++ map pkgs.lib.getDev (with pkgs; [
-            libblst libsodium-vrf secp256k1 #R_4_1_3
+            libblst libsodium-vrf secp256k1
         ]))
     ;
 })

--- a/cross-windows.nix
+++ b/cross-windows.nix
@@ -174,7 +174,8 @@ pkgs.pkgsBuildBuild.mkShell ({
         windows.mingw_w64_pthreads
     ])
     ++ pkgs.lib.optional (withHLS && (compiler-not-in (
-         pkgs.lib.optional (builtins.compareVersions compiler.version "9.9" >= 0) compiler-nix-name
+         # it appears we can't get HLS build with 9.8 yet.
+         pkgs.lib.optional (builtins.compareVersions compiler.version "9.7" >= 0) compiler-nix-name
       ++ pkgs.lib.optional (pkgs.stdenv.hostPlatform.isDarwin && pkgs.stdenv.hostPlatform.isAarch64) "ghc902") "Haskell Language Server")) (tool "haskell-language-server")
     ++ pkgs.lib.optional (withHlint && (compiler-not-in (
          pkgs.lib.optional (builtins.compareVersions compiler.version "9.8" >= 0) compiler-nix-name

--- a/dynamic.nix
+++ b/dynamic.nix
@@ -110,7 +110,7 @@ pkgs.mkShell {
         ]
         ++ map pkgs.lib.getDev (with pkgs; [ libblst libsodium-vrf secp256k1 icu ]
             ++ pkgs.lib.optional (withIOGFull) [
-                R          # for plutus
+                (if pkgs.stdenv.hostPlatform.isAarch64 then null else R) # for plutus; R is broken on aarch64
                 postgresql # for db-sync
             ]))
     ;

--- a/dynamic.nix
+++ b/dynamic.nix
@@ -104,12 +104,14 @@ pkgs.mkShell {
         (with pkgs; [
             cddl
             cbor-diag
-            #R_4_1_3      # for plutus
-            #postgresql   # for db-sync
             gh
             jq
             yq-go
         ]
-        ++ map pkgs.lib.getDev (with pkgs; [ libblst libsodium-vrf secp256k1 icu ] ++ pkgs.lib.optional (withIOGFull) [ R_4_1_3 postgresql ]))
+        ++ map pkgs.lib.getDev (with pkgs; [ libblst libsodium-vrf secp256k1 icu ]
+            ++ pkgs.lib.optional (withIOGFull) [
+                R          # for plutus
+                postgresql # for db-sync
+            ]))
     ;
 }

--- a/dynamic.nix
+++ b/dynamic.nix
@@ -95,7 +95,7 @@ pkgs.mkShell {
         ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux systemd
     )
     ++ pkgs.lib.optional (withHLS && (compiler-not-in (
-         pkgs.lib.optional (builtins.compareVersions compiler.version "9.10" >= 0) compiler-nix-name
+         pkgs.lib.optional (builtins.compareVersions compiler.version "9.7" >= 0) compiler-nix-name
       ++ pkgs.lib.optional (pkgs.stdenv.hostPlatform.isDarwin && pkgs.stdenv.hostPlatform.isAarch64) "ghc902") "Haskell Language Server")) (tool "haskell-language-server")
     ++ pkgs.lib.optional (withHlint && (compiler-not-in (
          pkgs.lib.optional (builtins.compareVersions compiler.version "9.10" >= 0) compiler-nix-name

--- a/dynamic.nix
+++ b/dynamic.nix
@@ -95,10 +95,10 @@ pkgs.mkShell {
         ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux systemd
     )
     ++ pkgs.lib.optional (withHLS && (compiler-not-in (
-         pkgs.lib.optional (builtins.compareVersions compiler.version "9.9" >= 0) compiler-nix-name
+         pkgs.lib.optional (builtins.compareVersions compiler.version "9.10" >= 0) compiler-nix-name
       ++ pkgs.lib.optional (pkgs.stdenv.hostPlatform.isDarwin && pkgs.stdenv.hostPlatform.isAarch64) "ghc902") "Haskell Language Server")) (tool "haskell-language-server")
     ++ pkgs.lib.optional (withHlint && (compiler-not-in (
-         pkgs.lib.optional (builtins.compareVersions compiler.version "9.8" >= 0) compiler-nix-name
+         pkgs.lib.optional (builtins.compareVersions compiler.version "9.10" >= 0) compiler-nix-name
       ++ pkgs.lib.optional (pkgs.stdenv.hostPlatform.isDarwin && pkgs.stdenv.hostPlatform.isAarch64) "ghc902") "HLint")) (tool "hlint")
     ++ pkgs.lib.optional withIOG
         (with pkgs; [

--- a/flake.lock
+++ b/flake.lock
@@ -152,33 +152,33 @@
         "type": "github"
       }
     },
-    "ghc98X": {
+    "ghc910X": {
       "flake": false,
       "locked": {
-        "lastModified": 1696643148,
-        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
-        "ref": "ghc-9.8",
-        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
-        "revCount": 61642,
+        "lastModified": 1711543129,
+        "narHash": "sha256-MUI07CxYOng7ZwHnMCw0ugY3HmWo2p/f4r07CGV7OAM=",
+        "ref": "ghc-9.10",
+        "rev": "6ecd5f2ff97af53c7334f2d8581651203a2c6b7d",
+        "revCount": 62607,
         "submodules": true,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc"
       },
       "original": {
-        "ref": "ghc-9.8",
+        "ref": "ghc-9.10",
         "submodules": true,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc"
       }
     },
-    "ghc99": {
+    "ghc911": {
       "flake": false,
       "locked": {
-        "lastModified": 1697054644,
-        "narHash": "sha256-kKarOuXUaAH3QWv7ASx+gGFMHaHKe0pK5Zu37ky2AL4=",
+        "lastModified": 1711538967,
+        "narHash": "sha256-KSdOJ8seP3g30FaC2du8QjU9vumMnmzPR5wfkVRXQMk=",
         "ref": "refs/heads/master",
-        "rev": "f383a242c76f90bcca8a4d7ee001dcb49c172a9a",
-        "revCount": 62040,
+        "rev": "0acfe391583d77a72051d505f05fab0ada056c49",
+        "revCount": 62632,
         "submodules": true,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc"
@@ -192,11 +192,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1697329475,
-        "narHash": "sha256-cyp4bvVyDWa27pv6Fc9mIXM7+Kn9dNv2tlGx13A0XsI=",
+        "lastModified": 1712967738,
+        "narHash": "sha256-jKx8KJxGHfdmFB2spyj58Na31cknm2RQWvo19vslF6U=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "c1d90e14c6ea1048275a97cd56546c3db116ad47",
+        "rev": "c3ab2f880ee6c8af1f51e5e5202e96a29144a953",
         "type": "github"
       },
       "original": {
@@ -214,14 +214,16 @@
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "ghc98X": "ghc98X",
-        "ghc99": "ghc99",
+        "ghc910X": "ghc910X",
+        "ghc911": "ghc911",
         "hackage": "hackage",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
+        "hls-2.5": "hls-2.5",
+        "hls-2.6": "hls-2.6",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -235,16 +237,17 @@
         "nixpkgs-2205": "nixpkgs-2205",
         "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1697415012,
-        "narHash": "sha256-QYeYRA9KbMuy+N4fYWTSHT571VUGmyN0TzOBYDh0ARo=",
+        "lastModified": 1712969356,
+        "narHash": "sha256-d0syrqLiyhwuOA8dAWHZ0N8NNI51JvhtXySQYt2XvAQ=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "4589f9d34ee36f3f622177fcd665c2e7084308d1",
+        "rev": "7400a707f2363fcb0dd9f3066672bbbad6976bb9",
         "type": "github"
       },
       "original": {
@@ -324,16 +327,50 @@
     "hls-2.4": {
       "flake": false,
       "locked": {
-        "lastModified": 1696939266,
-        "narHash": "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=",
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "362fdd1293efb4b82410b676ab1273479f6d17ee",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "2.4.0.0",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -401,18 +438,18 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1691634696,
-        "narHash": "sha256-MZH2NznKC/gbgBu8NgIibtSUZeJ00HTLJ0PlWKCBHb0=",
-        "ref": "hkm/remote-iserv",
-        "rev": "43a979272d9addc29fbffc2e8542c5d96e993d73",
-        "revCount": 14,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+        "lastModified": 1708894040,
+        "narHash": "sha256-Rv+PajrnuJ6AeyhtqzMN+bcR8z9+aEnrUass+N951CQ=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "2f2a318fd8837f8063a0d91f329aeae29055fba9",
+        "type": "github"
       },
       "original": {
-        "ref": "hkm/remote-iserv",
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
       }
     },
     "lowdown-src": {
@@ -550,16 +587,32 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1695416179,
-        "narHash": "sha256-610o1+pwbSu+QuF3GE0NU5xQdTHM3t9wyYhB9l94Cd8=",
+        "lastModified": 1701362232,
+        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "715d72e967ec1dd5ecc71290ee072bcaf5181ed6",
+        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311": {
+      "locked": {
+        "lastModified": 1701386440,
+        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -582,17 +635,17 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1695318763,
-        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
+        "lastModified": 1694822471,
+        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
@@ -677,11 +730,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1697328588,
-        "narHash": "sha256-IrRJzGiGRd4lq9U0dANDpoiSeHd4pnTVA76DbMC7fwA=",
+        "lastModified": 1712966994,
+        "narHash": "sha256-0MMsCMyHDO1jv/DZC+g3rcNTNk/zfE9oeHTlM/rU4MU=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "b6a72b7b02a9aa017169c639774fda1573fd09c3",
+        "rev": "5964d4ef5062c2530502330605200796801a1052",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -154,8 +154,16 @@
                     import ./static.nix (args // { withIOG = true; })
                   )) (compilers static-pkgs)
               // pkgs.lib.mapAttrs' (short-name: args:
+                  pkgs.lib.nameValuePair "${short-name}-static-iog-full" (
+                    import ./static.nix (args // { withIOG = true; withIOGFull = true;})
+                  )) (compilers static-pkgs)
+              // pkgs.lib.mapAttrs' (short-name: args:
                   pkgs.lib.nameValuePair "${short-name}-static-minimal-iog" (
                     import ./static.nix (args // { withHLS = false; withHlint = false; withIOG = true; })
+                  )) (compilers static-pkgs)
+              // pkgs.lib.mapAttrs' (short-name: args:
+                  pkgs.lib.nameValuePair "${short-name}-static-minimal-iog-full" (
+                    import ./static.nix (args // { withHLS = false; withHlint = false; withIOG = true; withIOGFull = true; })
                   )) (compilers static-pkgs)
               // pkgs.lib.mapAttrs' (short-name: args:
                   pkgs.lib.nameValuePair "${short-name}-js-iog" (

--- a/flake.nix
+++ b/flake.nix
@@ -86,8 +86,7 @@
                       "ghc92"
                       "ghc94"
                       "ghc96"
-                      "ghc98"
-                      "ghc99"] (short-name: rec {
+                      "ghc98"] (short-name: rec {
                          inherit pkgs self toolsModule;
                          compiler-nix-name = pkgs.haskell-nix.resolve-compiler-name short-name;
                          compiler = pkgs.buildPackages.haskell-nix.compiler.${compiler-nix-name};

--- a/flake.nix
+++ b/flake.nix
@@ -32,19 +32,8 @@
             '';
             postFixup = "";
           });
-        });
-         # the haskell inline-r package depends on internals of the R
-         # project that have been hidden in R 4.2+. See
-         # https://github.com/tweag/HaskellR/issues/374
-         oldR = (final: prev: {
-           R_4_1_3 = final.R.overrideDerivation (old: rec {
-             version = "4.1.3";
-             patches = []; # upstream patches will most likely break this build, as they are specific to a different version.
-             src = final.fetchurl {
-               url = "https://cran.r-project.org/src/base/R-${final.lib.versions.major version}/${old.pname}-${version}.tar.gz";
-               sha256 = "sha256-Ff9bMzxhCUBgsqUunB2OxVzELdAp45yiKr2qkJUm/tY="; };
-             });
          });
+
          cddl-tools = (final: prev: {
           cbor-diag = final.callPackage ./pkgs/cbor-diag { };
           cddl = final.callPackage ./pkgs/cddl { };

--- a/static.nix
+++ b/static.nix
@@ -1,4 +1,4 @@
-{ self, pkgs, compiler, compiler-nix-name, toolsModule, withHLS ? true, withHlint ? true, withIOG ? true }:
+{ self, pkgs, compiler, compiler-nix-name, toolsModule, withHLS ? true, withHlint ? true, withIOG ? true, withIOGFull ? false }:
 let tool-version-map = import ./tool-map.nix;
     tool = tool-name: pkgs.pkgsBuildBuild.haskell-nix.tool compiler-nix-name tool-name [(tool-version-map compiler-nix-name tool-name) toolsModule];
     cabal-install = pkgs.pkgsBuildBuild.haskell-nix.nix-tools-unchecked.exes.cabal;
@@ -121,12 +121,13 @@ pkgs.mkShell (rec {
         static-libblst
         static-libsodium-vrf
         static-secp256k1
-        #R_4_1_3      # for plutus
-        postgresql    # for db-sync
         icu           # for cardano-cli
         gh
         jq
         yq-go
+    ] ++ lib.options withIOGFull [
+        R          # for plutus
+        postgresql # for db-sync
     ]);
 
     # these are _native_ libs, we need to drive the compilation environment

--- a/static.nix
+++ b/static.nix
@@ -142,7 +142,7 @@ pkgs.mkShell (rec {
         stdenv.cc.cc.lib ]) ++ (with pkgs.buildPackages; [
     ])
     ++ pkgs.lib.optional (withHLS && (compiler-not-in (
-         pkgs.lib.optional (builtins.compareVersions compiler.version "9.9" >= 0) compiler-nix-name) "Haskell Language Server")) (tool "haskell-language-server")
+         pkgs.lib.optional (builtins.compareVersions compiler.version "9.7" >= 0) compiler-nix-name) "Haskell Language Server")) (tool "haskell-language-server")
     ++ pkgs.lib.optional (withHlint && (compiler-not-in (
          pkgs.lib.optional (builtins.compareVersions compiler.version "9.8" >= 0) compiler-nix-name) "HLint")) (tool "hlint")
     ++ pkgs.lib.optional withIOG (with pkgs; [ cddl cbor-diag ])

--- a/static.nix
+++ b/static.nix
@@ -125,7 +125,7 @@ pkgs.mkShell (rec {
         gh
         jq
         yq-go
-    ] ++ lib.options withIOGFull [
+    ] ++ lib.optionals withIOGFull [
         R          # for plutus
         postgresql # for db-sync
     ]);

--- a/static.nix
+++ b/static.nix
@@ -126,7 +126,7 @@ pkgs.mkShell (rec {
         jq
         yq-go
     ] ++ lib.optionals withIOGFull [
-        R          # for plutus
+        (if pkgs.stdenv.hostPlatform.isAarch64 then null else R) # for plutus; but unavailable for static/aarch64
         postgresql # for db-sync
     ]);
 

--- a/static.nix
+++ b/static.nix
@@ -126,7 +126,9 @@ pkgs.mkShell (rec {
         jq
         yq-go
     ] ++ lib.optionals withIOGFull [
-        (if pkgs.stdenv.hostPlatform.isAarch64 then null else R) # for plutus; but unavailable for static/aarch64
+        # for plutus; but unavailable for static/aarch64, or static even.
+        # R fails in almost any direction. For now, we just disable it.
+        (if (pkgs.stdenv.hostPlatform.isAarch64 || pkgs.stdenv.hostPlatform.isMusl) then null else R)
         postgresql # for db-sync
     ]);
 

--- a/tool-map.nix
+++ b/tool-map.nix
@@ -27,15 +27,18 @@ compiler-nix-name: tool: {
   # for HLS, we rely on the cabal.project configuration from the upstream project to have the correct configuration.
   # Building HLS from hackage requires setting all those constraints as well, and just isn't practical to do for each
   # HLS release. Therefore we rely on the HLS upstream repository to provide the proper configuration information.
+  #
+  # The fact that we duplicate logic from haskell.nix here is quite annoying:
+  #
+  #  https://github.com/input-output-hk/haskell.nix/blob/dbf7e3e722f9d02ed9776d02f934280fb972a669/build.nix#L54-L66
+  #
+  # Ideally we should expose this from haskell.nix
   haskell-language-server = {pkgs, ...}: rec {
       # Use the github source of HLS that is tested with haskell.nix CI
-      src = { "ghc8107" = pkgs.haskell-nix.sources."hls-2.2"; }.${compiler-nix-name} or pkgs.haskell-nix.sources."hls-2.4";
+      src = { "ghc8107" = pkgs.haskell-nix.sources."hls-2.2"; }.${compiler-nix-name} or pkgs.haskell-nix.sources."hls-2.6";
       # `tool` normally ignores the `cabal.project` (if there is one in the hackage source).
       # We need to use the github one (since it has settings to make hls build).
       cabalProject = __readFile (src + "/cabal.project");
-      inherit cabalProjectLocal;
-      # sha256 for a `source-repository-package` in the `cabal.project` file.
-      sha256map."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
   };
   happy = { version = "1.20.1.1"; inherit cabalProjectLocal; };
   alex = { version = "3.2.7.3"; inherit cabalProjectLocal; };

--- a/tool-map.nix
+++ b/tool-map.nix
@@ -35,7 +35,9 @@ compiler-nix-name: tool: {
   # Ideally we should expose this from haskell.nix
   haskell-language-server = {pkgs, ...}: rec {
       # Use the github source of HLS that is tested with haskell.nix CI
-      src = { "ghc8107" = pkgs.haskell-nix.sources."hls-2.2"; }.${compiler-nix-name} or pkgs.haskell-nix.sources."hls-2.6";
+      src = { "ghc8107" = pkgs.haskell-nix.sources."hls-2.2";
+              "ghc902"  = pkgs.haskell-nix.sources."hls-2.4";
+            }.${compiler-nix-name} or pkgs.haskell-nix.sources."hls-2.6";
       # `tool` normally ignores the `cabal.project` (if there is one in the hackage source).
       # We need to use the github one (since it has settings to make hls build).
       cabalProject = __readFile (src + "/cabal.project");

--- a/tool-map.nix
+++ b/tool-map.nix
@@ -2,7 +2,10 @@
 # so we assume "latest" for all hls.
 # for hlint however, we need hlint-3.3 for ghc-8.10.7.
 let
-  fixed-versions = { "hlint" = { "ghc8107" = { version = "3.4.1"; }; "ghc902" = { version = "3.5"; }; }; };
+  fixed-versions = { "hlint" = { "ghc8107" = { version = "3.4.1"; };
+                                 "ghc902"  = { version = "3.5"; };
+                                 "ghc928"  = { version = "3.6.1"; };
+                               }; };
   cabalProjectLocal = ''
         repository head.hackage.ghc.haskell.org
           url: https://ghc.gitlab.haskell.org/head.hackage/
@@ -14,7 +17,7 @@ let
              7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
           --sha256: sha256-aVI93DtHziicNn2mGli0YE+bC5BeT7mOQQETp2Thi68=
 
-        if impl(ghc < 9.7)
+        if impl(ghc < 9.11)
           active-repositories: hackage.haskell.org
         else
           active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org


### PR DESCRIPTION
```
% nix flake lock --update-input haskellNix
warning: updating lock file '/Users/yvan/GitHub/devx/flake.lock':
• Updated input 'haskellNix':
    'github:input-output-hk/haskell.nix/4589f9d34ee36f3f622177fcd665c2e7084308d1' (2023-10-16)
  → 'github:input-output-hk/haskell.nix/e8a8f03518ab36c8cc3418b3190d450af696a4ac' (2024-03-29)
• Added input 'haskellNix/ghc910X':
    'git+https://gitlab.haskell.org/ghc/ghc?ref=ghc-9.10&rev=21e3f3250e88640087a1a60bee2cc113bf04509f' (2024-03-06)
• Added input 'haskellNix/ghc911':
    'git+https://gitlab.haskell.org/ghc/ghc?ref=refs/heads/master&rev=e6bfb85c842edca36754bb8914e725fbaa1a83a6' (2024-03-12)
• Removed input 'haskellNix/ghc98X'
• Removed input 'haskellNix/ghc99'
• Updated input 'haskellNix/hackage':
    'github:input-output-hk/hackage.nix/c1d90e14c6ea1048275a97cd56546c3db116ad47' (2023-10-15)
  → 'github:input-output-hk/hackage.nix/43759d81df9167604df47f756325b5f91e456f4a' (2024-03-29)
• Updated input 'haskellNix/hls-2.4':
    'github:haskell/haskell-language-server/362fdd1293efb4b82410b676ab1273479f6d17ee' (2023-10-10)
  → 'github:haskell/haskell-language-server/54507ef7e85fa8e9d0eb9a669832a3287ffccd57' (2023-11-13)
• Added input 'haskellNix/hls-2.5':
    'github:haskell/haskell-language-server/27f8c3d3892e38edaef5bea3870161815c4d014c' (2023-11-27)
• Added input 'haskellNix/hls-2.6':
    'github:haskell/haskell-language-server/6e0b342fa0327e628610f2711f8c3e4eaaa08b1e' (2024-01-15)
• Updated input 'haskellNix/iserv-proxy':
    'git+https://gitlab.haskell.org/hamishmack/iserv-proxy.git?ref=hkm/remote-iserv&rev=43a979272d9addc29fbffc2e8542c5d96e993d73' (2023-08-10)
  → 'github:stable-haskell/iserv-proxy/2f2a318fd8837f8063a0d91f329aeae29055fba9' (2024-02-25)
• Added input 'haskellNix/nix-tools-static':
    'github:input-output-hk/haskell-nix-example/580cb6db546a7777dad3b9c0fa487a366c045c4e' (2024-01-26)
• Updated input 'haskellNix/nixpkgs-2305':
    'github:NixOS/nixpkgs/715d72e967ec1dd5ecc71290ee072bcaf5181ed6' (2023-09-22)
  → 'github:NixOS/nixpkgs/d2332963662edffacfddfad59ff4f709dde80ffe' (2023-11-30)
• Added input 'haskellNix/nixpkgs-2311':
    'github:NixOS/nixpkgs/293822e55ec1872f715a66d0eda9e592dc14419f' (2023-11-30)
• Updated input 'haskellNix/nixpkgs-unstable':
    'github:NixOS/nixpkgs/e12483116b3b51a185a33a272bf351e357ba9a99' (2023-09-21)
  → 'github:NixOS/nixpkgs/47585496bcb13fb72e4a90daeea2f434e2501998' (2023-09-16)
• Updated input 'haskellNix/stackage':
    'github:input-output-hk/stackage.nix/b6a72b7b02a9aa017169c639774fda1573fd09c3' (2023-10-15)
  → 'github:input-output-hk/stackage.nix/7154130a3a0c7f47df4854f2939a0c1b401ba285' (2024-03-29)
  ```
  
  ```
  % nix develop ".#ghc96-minimal"
warning: Git tree '/Users/yvan/GitHub/devx' is dirty
trace: WARNING: 9.6.2 is out of date, consider using 9.6.4.
                                                                     
 _____ _____ _____    _____         _       _ _    _____ _       _ _ 
|     |     |   __|  |  |  |___ ___| |_ ___| | |  |   __| |_ ___| | |
|-   -|  |  |  |  |  |     | .'|_ -| '_| -_| | |  |__   |   | -_| | |
|_____|_____|_____|  |__|__|__,|___|_,_|___|_|_|  |_____|_|_|___|_|_|
                                                                     
Revision (input-output-hk/devx): unknown/dirty checkout.
CABAL_DIR set to /Users/yvan/.cabal-devx
(nix:nix-shell-env)040[~/GitHub/devx]$ ghc --version
The Glorious Glasgow Haskell Compilation System, version 9.6.4
```