### PR TITLE
Add instructions on how to use DevContainers outside of GitHub or VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ It's also advised to enable GitHub CodeSpace prebuilds in your repository settin
 
 List of images available: `ghc810-iog`, `ghc96-iog`, `ghc810-js-iog`, `ghc96-js-iog`, `ghc810-windows-iog`, `ghc96-windows-iog`.
 
+> [!TIP]
+> If you wish to utilize the DevContainer as a normal Docker container outside of GitHub or VSCode, remember to prefix your commands with `bash -ic`. This is necessary because the Nix developer environment is loaded through `~/.bashrc`.
+> E.g., `docker run -it ghcr.io/input-output-hk/devx-devcontainer:x86_64-linux.ghc96-iog bash -ic "cabal --version"`
+
 ## Compilers and Flavors
 
 There are multiple compilers available, and usually the latest for each series


### PR DESCRIPTION
This is a follow-up to an issue encountered by @zeme-wana. He suggested that this information could be added to the README :)

[Rendered](https://github.com/input-output-hk/devx/blob/readme-devcontainer-tips/README.md#vscode-devcontainer--github-codespace-support)