### PR TITLE
Add hint to reproduce the devshell flavor locally if within GitHub Action

### DIFF
--- a/cross-js.nix
+++ b/cross-js.nix
@@ -61,14 +61,21 @@ pkgs.mkShell ({
 
     inherit (quirks) CABAL_PROJECT_LOCAL_TEMPLATE;
 
-    shellHook = with pkgs; ''
+    shellHook =
+        with pkgs;
+        let flavor = "${compiler-nix-name}-js"
+                   + lib.optionalString (!withHLS && !withHlint) "-minimal"
+                   + lib.optionalString withIOG                  "-iog"
+                   ;
+        in ''
         export PS1="\[\033[01;33m\][\w]$\[\033[00m\] "
         ${figlet}/bin/figlet -f rectangles 'IOG Haskell Shell'
         ${figlet}/bin/figlet -f small "*= JS edition =*"
         echo "Revision (input-output-hk/devx): ${if self ? rev then self.rev else "unknown/dirty checkout"}."
         export CABAL_DIR=$HOME/.cabal-js
         echo "CABAL_DIR set to $CABAL_DIR"
-    '' + quirks.shellHook;
+        echo ""
+    '' + (quirks.hint flavor) + quirks.shellHook;
     buildInputs = [];
 
     nativeBuildInputs = [ wrapped-hsc2hs wrapped-cabal compiler ] ++ (with pkgs; [

--- a/cross-windows.nix
+++ b/cross-windows.nix
@@ -143,14 +143,21 @@ pkgs.pkgsBuildBuild.mkShell ({
 
     inherit (quirks) CABAL_PROJECT_LOCAL_TEMPLATE;
 
-    shellHook = with pkgs; ''
+    shellHook =
+      with pkgs;
+      let flavor = "${compiler-nix-name}-windows"
+                  + lib.optionalString (!withHLS && !withHlint) "-minimal"
+                  + lib.optionalString withIOG                  "-iog"
+                  ;
+      in ''
       export PS1="\[\033[01;33m\][\w]$\[\033[00m\] "
       ${pkgsBuildBuild.figlet}/bin/figlet -f rectangles 'IOG Haskell Shell'
       ${pkgsBuildBuild.figlet}/bin/figlet -f small "*= Windows =*"
       echo "Revision (input-output-hk/devx): ${if self ? rev then self.rev else "unknown/dirty checkout"}."
       export CABAL_DIR=$HOME/.cabal-windows
       echo "CABAL_DIR set to $CABAL_DIR"
-    '' + quirks.shellHook;
+      echo ""
+    '' + (quirks.hint flavor) + quirks.shellHook;
     buildInputs = [];
 
     nativeBuildInputs = [ wrapped-ghc wrapped-hsc2hs wrapped-cabal wine-test-wrapper compiler ] ++ (with pkgs; [

--- a/quirks.nix
+++ b/quirks.nix
@@ -18,5 +18,13 @@
     function patchProjectLocal() {
       cat ${template} >> "$1"
     }
+    echo ""
+  '';
+  hint = flavor: ''
+    if [ "$GITHUB_ACTIONS" = "true" ]; then
+	    echo "::notice::Hint: to reproduce this environment locally, use either:" \
+           "\`nix develop github:input-output-hk/devx#${flavor}\`, or" \
+           "\`docker run -it -v \$(pwd):/workspaces ghcr.io/input-output-hk/devx-devcontainer:x86_64-linux.${flavor}\`"
+    fi
   '';
 }

--- a/static.nix
+++ b/static.nix
@@ -87,7 +87,13 @@ pkgs.mkShell (rec {
     # the system path.
     DYLD_LIBRARY_PATH= with pkgs; "${lib.getLib openssl}/lib";
 
-    shellHook = with pkgs; ''
+    shellHook =
+        with pkgs;
+        let flavor = "${compiler-nix-name}-static"
+                   + lib.optionalString (!withHLS && !withHlint) "-minimal"
+                   + lib.optionalString withIOG                  "-iog"
+                   ;
+        in ''
         export PS1="\[\033[01;33m\][\w]$\[\033[00m\] "
         export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}";
         ${figlet}/bin/figlet -f rectangles 'IOG Haskell Shell'
@@ -97,7 +103,8 @@ pkgs.mkShell (rec {
         export CABAL_DIR=$HOME/.cabal-static
         echo "CABAL_DIR set to $CABAL_DIR"
         echo "DYLD_LIBRARY_PATH set to $DYLD_LIBRARY_PATH"
-    '' + quirks.shellHook;
+        echo ""
+    '' + (quirks.hint flavor) + quirks.shellHook;
     # these are _target_ libs, e.g. ones we want to link the build
     # product against. These are also the ones that showup in the
     # PKG_CONFIG_PATH.


### PR DESCRIPTION
As suggested by @angerman, in response to issues that @erikd and @sgillespie got while debugging [`db-sync` actions](https://github.com/IntersectMBO/cardano-db-sync/actions/runs/8517329880/job/23327725038?pr=1636).

The output looks like:
```
% export GITHUB_ACTIONS=true
% nix develop ".#ghc96"     
                                                                     
 _____ _____ _____    _____         _       _ _    _____ _       _ _ 
|     |     |   __|  |  |  |___ ___| |_ ___| | |  |   __| |_ ___| | |
|-   -|  |  |  |  |  |     | .'|_ -| '_| -_| | |  |__   |   | -_| | |
|_____|_____|_____|  |__|__|__,|___|_,_|___|_|_|  |_____|_|_|___|_|_|
                                                                     
Revision (input-output-hk/devx): 6b241faf9b5ebe1fbbfbd56d0cf96867bf8477e9.
CABAL_DIR set to /Users/yvan/.cabal-devx

Hint: to reproduce this environment locally, use either:
$ nix develop github:input-output-hk/devx#ghc963
$ docker run -it -v $(pwd):/workspaces ghcr.io/input-output-hk/devx-devcontainer:x86_64-linux.ghc963

(nix:nix-shell-env)040[~/GitHub/devx]$ 
```
