### PR TITLE
Finish the `-iog-full` flavor by generating the corresponding `devx-container`

### DIFF
--- a/.github/workflows/wait-and-upload.yml
+++ b/.github/workflows/wait-and-upload.yml
@@ -117,7 +117,7 @@ jobs:
     # Likely, we consider using `-iog` as the default and do not generate other images.
     # Then the user choices left would be between native, `-windows` or `-js` target platforms,
     # and the GHC version (currently `ghc810` and `ghc96`).
-    if: ${{ contains(fromJSON('["x86_64-linux", "aarch64-linux"]'), inputs.platform) && contains(fromJson('["","-windows","-js"]'), inputs.target-platform) && contains(fromJson('["ghc810","ghc96"]'), inputs.compiler-nix-name) && !inputs.minimal && inputs.iog }}
+    if: ${{ contains(fromJSON('["x86_64-linux", "aarch64-linux"]'), inputs.platform) && contains(fromJson('["","-windows","-js"]'), inputs.target-platform) && contains(fromJson('["ghc810","ghc96"]'), inputs.compiler-nix-name) && !inputs.minimal }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -134,13 +134,14 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.platform }}.${{ inputs.compiler-nix-name }}${{ inputs.target-platform }}-iog
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.platform }}.${{ inputs.compiler-nix-name }}${{ inputs.target-platform }}${{ inputs.iog-full || inputs.iog }}
           build-args: |
             PLATFORM=${{ inputs.platform }}
             TARGET_PLATFORM=${{ inputs.target-platform }}
             COMPILER_NIX_NAME=${{ inputs.compiler-nix-name }}
             MINIMAL=${{ inputs.minimal }}
             IOG=${{ inputs.iog }}
+            IOG_FULL=${{ inputs.iog-full }}
 
   codespace-download:
     env:
@@ -170,5 +171,5 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run test command inside the Dev Container
-        run: docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.platform }}.${{ inputs.compiler-nix-name }}${{ inputs.target-platform }}-iog \
+        run: docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.platform }}.${{ inputs.compiler-nix-name }}${{ inputs.target-platform }} \
              /bin/bash -c "cabal update && cabal unpack hello && cd hello-* && cabal build"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
  && SUFFIX='' \
  && if [ "$MINIMAL" = "true" ]; then SUFFIX="${SUFFIX}-minimal"; fi \
  && if [ "$IOG" = "true" ]; then SUFFIX="${SUFFIX}-iog"; fi \
+ && if [ "$IOG_FULL" = "true" ]; then SUFFIX="${SUFFIX}-iog-full"; fi \
  && ./fetch-docker.sh input-output-hk/devx $PLATFORM.$COMPILER_NIX_NAME$TARGET_PLATFORM${SUFFIX}-env | zstd -d | nix-store --import | tee store-paths.txt \
  && apt-get -y remove curl git jq nix zstd \
  && apt-get -y autoremove \

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ There are various flavors available as suffixes to the compiler names (e.g. `#gh
 | Flavor | Description | Example | Included |
 | - | - | - | - |
 | empty | General Haskell Dev | `#ghc810` | `ghc`, `cabal-install`, `hls`, `hlint` |
-| `-iog` | IOG Haskell Dev | `#ghc810` | adds `sodium-vrf`, `blst`, `secp256k1`, `R`, `postgresql` |
+| `-iog` | IOG Haskell Dev | `#ghc810` | adds `sodium-vrf`, `blst`, `secp256k1` |
+| `-iog-full` | IOG Haskell Dev | `#ghc810` | adds `sodium-vrf`, `blst`, `secp256k1`, `R`, `postgresql` |
 | `-minimal` | Only GHC, and Cabal | `#ghc810-minimal` | drops `hls`, `hlint` |
 | `-static` | Building static binaries | `#ghc810-static` | Static Haskell Cross-Compiler |
 | `-js` | JavaScript Cross-Compiler | `#ghc810-js` | JavaScript Haskell Cross-Compiler |


### PR DESCRIPTION
I also updated the README: [Rendered](https://github.com/input-output-hk/devx/blob/iog-full-devx-container/README.md#compilers-and-flavors)