### PR TITLE
Fix `CODESPACE_TOKEN: unbound variable`

### DIFF
--- a/quirks.nix
+++ b/quirks.nix
@@ -26,12 +26,12 @@
     else
         PREFIX="Hint:"
     fi
-    if [ "$GITHUB_ACTIONS" = "true" ] || [ -n "$CODESPACE_TOKEN" ]; then
+    if [ "$GITHUB_ACTIONS" = "true" ] || [ -v CODESPACE_TOKEN ]; then
         echo "$PREFIX to reproduce this environment locally, use either:" \
              "\`nix develop github:input-output-hk/devx#${flavor}\`, or" \
              "\`docker run -it -v \$(pwd):/workspaces ghcr.io/input-output-hk/devx-devcontainer:x86_64-linux.${flavor}\`"
     fi
-    if [ -n "$CODESPACE_TOKEN" ]; then
+    if [ -v CODESPACE_TOKEN ]; then
         echo "Quirks:"
         echo -e "\tThe Haskell VSCode extension might ask you \"How do you want the extension to manage/discover HLS and the relevant toolchain?\""
         echo -e "\tChoose \"Manually via PATH\", not \"Automatically via GHCup\""


### PR DESCRIPTION
```
Revision (input-output-hk/devx): 0a5cefb55c8c41cbc6119370dfdb8d8f78832633. /nix/store/2nigzj6x6d0qkzqvvyf5604g0581r8z6-ghc810-env.sh: line 1937: CODESPACE_TOKEN: unbound variable CABAL_DIR set to /Users/runner/.cabal-devx

Notice: Hint: to reproduce this environment locally, use either: `nix develop github:input-output-hk/devx#ghc8107`, or `docker run -it -v $(pwd):/workspaces ghcr.io/input-output-hk/devx-devcontainer:x86_64-linux.ghc8107`
```