### PR TITLE
No more Node.js 16

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ inputs.platform == 'x86_64-linux' && 'ubuntu-latest' || 'macos-latest' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install GHC and Cabal
       uses: input-output-hk/actions/devx@latest
       with:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -25,7 +25,7 @@ jobs:
   deadnix:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: |
           nix run github:astro/deadnix -- --edit --no-lambda-pattern-names
           TMPFILE=$(mktemp)
@@ -36,7 +36,7 @@ jobs:
   nixprof:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/wait-and-upload.yml
+++ b/.github/workflows/wait-and-upload.yml
@@ -79,7 +79,7 @@ jobs:
             substituters = https://cache.iog.io/ https://cache.zw3rk.com/ https://cache.nixos.org/
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Log in to the Container registry
         uses: docker/login-action@v2.1.0
         with:
@@ -119,7 +119,7 @@ jobs:
     if: ${{ contains(fromJSON('["x86_64-linux", "aarch64-linux"]'), inputs.platform) && contains(fromJson('["","-windows","-js"]'), inputs.target-platform) && contains(fromJson('["ghc810","ghc96"]'), inputs.compiler-nix-name) && inputs.variant == '' && inputs.iog == '-iog' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2.1.0


### PR DESCRIPTION
GH wants to move to node 20 instead of 16. This necessitates migrating @v3 actions to @v4.