### PR TITLE
Retrieve `~/.cabal-devx` and `~/.cache` from GHA cache in Codespaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,9 @@ if [ -n "\$PROJECT_DIR" ]; then
         echo "Attempting to download HLS cache from GitHub Artifact (cache-\$COMMIT_HASH-$COMPILER_NIX_NAME) for faster first launch ..."
         gh run download -D .download -n "cache-\$COMMIT_HASH-$COMPILER_NIX_NAME"
         if [ -n .download ]; then
-            rsync -a .download/ dist-newstyle/
+            rsync -a .download/dist-newstyle dist-newstyle
+            rsync -a .download/.cabal-devx   $HOME/.cabal-devx
+            rsync -a .download/.cache        $HOME/.cache
             rm -r .download
         fi
     else


### PR DESCRIPTION
Needs https://github.com/input-output-hk/actions/pull/19 to be merged first