### PR TITLE
Fix `[: -v: unary operator expected`

### DIFF
--- a/quirks.nix
+++ b/quirks.nix
@@ -26,12 +26,12 @@
     else
         PREFIX="Hint:"
     fi
-    if [ "$GITHUB_ACTIONS" = "true" ] || [ -v CODESPACE_TOKEN ]; then
+    if [ "$GITHUB_ACTIONS" = "true" ] || [ "$${CODESPACE_TOKEN+x}" = "x" ]; then
         echo "$PREFIX to reproduce this environment locally, use either:" \
              "\`nix develop github:input-output-hk/devx#${flavor}\`, or" \
              "\`docker run -it -v \$(pwd):/workspaces ghcr.io/input-output-hk/devx-devcontainer:x86_64-linux.${flavor}\`"
     fi
-    if [ -v CODESPACE_TOKEN ]; then
+    if [ "$${CODESPACE_TOKEN+x}" = "x" ]; then
         echo "Quirks:"
         echo -e "\tThe Haskell VSCode extension might ask you \"How do you want the extension to manage/discover HLS and the relevant toolchain?\""
         echo -e "\tChoose \"Manually via PATH\", not \"Automatically via GHCup\""

--- a/quirks.nix
+++ b/quirks.nix
@@ -26,12 +26,12 @@
     else
         PREFIX="Hint:"
     fi
-    if [ "$GITHUB_ACTIONS" = "true" ] || [ "$${CODESPACE_TOKEN+x}" = "x" ]; then
+    if [ "$GITHUB_ACTIONS" = "true" ] || [ "$'' + ''{CODESPACE_TOKEN+x}" = "x" ]; then
         echo "$PREFIX to reproduce this environment locally, use either:" \
              "\`nix develop github:input-output-hk/devx#${flavor}\`, or" \
              "\`docker run -it -v \$(pwd):/workspaces ghcr.io/input-output-hk/devx-devcontainer:x86_64-linux.${flavor}\`"
     fi
-    if [ "$${CODESPACE_TOKEN+x}" = "x" ]; then
+    if [ "$'' + ''{CODESPACE_TOKEN+x}" = "x" ]; then
         echo "Quirks:"
         echo -e "\tThe Haskell VSCode extension might ask you \"How do you want the extension to manage/discover HLS and the relevant toolchain?\""
         echo -e "\tChoose \"Manually via PATH\", not \"Automatically via GHCup\""


### PR DESCRIPTION
```
/nix/store/1zcy75q3dr61bka5h4r8rf3kv8k18kw3-ghc96-iog-env.sh: line 1944: [: -v: unary operator expected
```
e.g. seen on https://github.com/IntersectMBO/cardano-node/actions/runs/8977554294/job/24656515205?pr=5817, in the Build all step.