### PR TITLE
fix: Use dynamic ruby even in static variants

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,8 @@
          });
 
          musl = (final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl {
+           # We don't need a ruby static build. We're only interested in producing static
+           # outputs, not necessarily build tools.
            ruby = prev.pkgsBuildBuild.ruby;
 
            # Tests on static postgresql are failing with:

--- a/flake.nix
+++ b/flake.nix
@@ -40,18 +40,7 @@
          });
 
          musl = (final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl {
-           # Fix the following Ruby cross build error:
-           #
-           #     error: output '/nix/store/6hyyk9wnnxpd5rsr6ivc0s8l1lgvsjrb-ruby-x86_64-unknown-linux-musl-3.3.4'
-           #     is not allowed to refer to the following paths:
-           #             /nix/store/c77wdd4fb0llq37bpmfr73m7s7r1j068-ruby-3.3.4
-           #
-           # See https://github.com/NixOS/nixpkgs/issues/347758
-           ruby = prev.ruby.overrideAttrs (old: {
-             postInstall = old.postInstall + ''
-               find $out/${old.passthru.gemPath} -name exts.mk -delete
-             '';
-           });
+           ruby = prev.pkgsBuildBuild.ruby;
 
            # Tests on static postgresql are failing with:
            #


### PR DESCRIPTION
Static shell variants are currently failing with

```
In file included from bigdecimal.h:14,
                 from bigdecimal.c:11:
missing.h:127:1: error: static declaration of 'rb_rational_num' follows non-static declaration
  127 | rb_rational_num(VALUE rat)
      | ^~~~~~~~~~~~~~~
```

But It's not important to use static ruby anyways, because we are interested in producing static artifacts, not the build tools themselves.

So, this change

 * Removes static ruby in favor of the regular one
 * Removes patches that fixes static ruby