### PR TITLE
Add liblmdb to IOG profiles

### DIFF
--- a/dynamic.nix
+++ b/dynamic.nix
@@ -124,6 +124,7 @@ pkgs.mkShell {
           jq
           libblst
           libsodium-vrf
+          lmdb          # for cardano-lmdb/ouroboros-consensus
           secp256k1
           yq-go
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,12 @@
             '';
             postFixup = "";
           });
+          static-lmdb = final.lmdb.overrideDerivation (old: {
+            # Don't attempt the .so if static, as it would fail.
+            postPatch = ''
+              sed 's/^ILIBS\>.*/ILIBS = liblmdb.a/' -i Makefile
+            '';
+          });
          });
 
          cddl-tools = (final: prev: {

--- a/static.nix
+++ b/static.nix
@@ -128,6 +128,7 @@ pkgs.mkShell (rec {
         static-libblst
         static-libsodium-vrf
         static-secp256k1
+        static-lmdb   # for cardano-lmdb/ouroboros-consensus
         icu           # for cardano-cli
         gh
         jq


### PR DESCRIPTION
Add the lmdb dev library to IOG profile, since it is required by ouroboros-consensus and cardano-lmdb. It fixes the GitHub build failure:

    [__2] next goal: cardano-lmdb (dependency of ouroboros-consensus)
    [__2] rejecting: cardano-lmdb; 0.4.0.3, 0.4.0.2, 0.4.0.1, 0.4.0.0 (conflict: pkg-config package lmdb>=0.9 && <0.10, not found in the pkg-config database)
    [__2] rejecting: cardano-lmdb-0.3.0.0 (conflict: ouroboros-consensus => cardano-lmdb>=0.4)
    [__2] fail (backjumping, conflict set: cardano-lmdb, ouroboros-consensus)
    After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: ouroboros-consensus, cardano-chain-gen, cardano-node, cardano-db-sync, cardano-lmdb
    Try running with --minimize-conflict-set to improve the error message.

Note that I had to copy the postPatch from nixpkgs, since musl64 is not considered a static platform.