### PR TITLE
test: wait-for-hydra SSE endpoint

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -15,7 +15,7 @@ jobs:
     name: Wait for Hydra status
     runs-on: ubuntu-latest
     steps:
-    - uses: input-output-hk/actions/wait-for-hydra@wait-for-hydra/sse-support
+    - uses: input-output-hk/actions/wait-for-hydra@latest
       with:
         check: required
         hydra-status-url: https://ci.zw3rk.com

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -15,9 +15,10 @@ jobs:
     name: Wait for Hydra status
     runs-on: ubuntu-latest
     steps:
-    - uses: input-output-hk/actions/wait-for-hydra@latest
+    - uses: input-output-hk/actions/wait-for-hydra@wait-for-hydra/sse-support
       with:
         check: required
+        hydra-status-url: https://ci.zw3rk.com
 
   discover:
     needs: wait-for-hydra


### PR DESCRIPTION
## Summary
- Test PR to validate the new SSE-enabled `wait-for-hydra` action
- Points `pr-validate.yml` at `input-output-hk/actions/wait-for-hydra@wait-for-hydra/sse-support`
- Uses `hydra-status-url: https://ci.zw3rk.com` for real-time build status via SSE

**Do not merge** — test PR only.