### PR TITLE
Fix container upload when Hydra skips individual check-runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,15 +31,40 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-    - name: Discover Hydra build check-runs
+    - name: Install Nix (for fallback discovery)
+      uses: cachix/install-nix-action@v20
+      with:
+        extra_nix_config: |
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk=
+          substituters = https://cache.iog.io/ https://cache.zw3rk.com/ https://cache.nixos.org/
+        nix_path: nixpkgs=channel:nixos-unstable
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Discover devShell -env closures
       id: set-matrix
       run: |
-        # Group the output by platform.
+        PLATFORM="${{ inputs.platform }}"
+
+        # Primary: discover from Hydra check-runs (fastest path).
+        # Each Hydra build check-run has the Nix store path in output.summary.
         RUNS=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs" --paginate)
-        echo "checks..."
-        FILTERED=$(jq -c -r '.check_runs[] | select(.name | endswith("-env")) | select(.name | startswith("${{ inputs.platform }}")) | { "config": .name, "build_path": .output.summary, "short_name": .name | sub("${{ inputs.platform }}\\.";"") }' <<< "$RUNS")
-        jq . <<< "$FILTERED"
+        echo "Checking Hydra check-runs for -env closures..."
+        FILTERED=$(jq -c -r '.check_runs[] | select(.name | endswith("-env")) | select(.name | startswith("'"$PLATFORM"'")) | { "config": .name, "build_path": .output.summary, "short_name": .name | sub("'"$PLATFORM"'\\.";"") }' <<< "$RUNS")
         MATRIX=$(jq --slurp -c -r '.' <<< "$FILTERED")
+
+        if [ "$MATRIX" != "[]" ]; then
+          echo "Found $(echo "$MATRIX" | jq length) -env closures from Hydra check-runs."
+        else
+          # Fallback: evaluate store paths directly from the flake.
+          # When Hydra resolves builds from cache, it may not create
+          # individual GitHub check-runs — only the aggregate "required".
+          # In that case, we compute the -env store paths ourselves.
+          echo "::warning::No -env check-runs found. Evaluating store paths from flake..."
+          MATRIX=$(nix eval ".#hydraJobs.${PLATFORM}" --json \
+            --apply "import ./extra/discover-env.nix \"${PLATFORM}\"")
+          echo "Evaluated $(echo "$MATRIX" | jq length) -env closures from flake."
+        fi
+
         jq . <<< "$MATRIX"
         echo "creating result matrix."
         echo "matrix=$MATRIX" >> $GITHUB_OUTPUT

--- a/extra/discover-env.nix
+++ b/extra/discover-env.nix
@@ -1,0 +1,23 @@
+# extra/discover-env.nix — Discover -env closure store paths from the flake.
+#
+# Copyright 2026 Input Output Group
+# SPDX-License-Identifier: Apache-2.0
+#
+# Used by the GHA upload workflow as a fallback when Hydra does not create
+# individual GitHub check-runs for cached builds.  Evaluates the flake's
+# hydraJobs and returns a JSON array of {config, build_path, short_name}
+# for every -env attribute on the given platform.
+#
+# Usage:
+#   nix eval ".#hydraJobs.<platform>" --json --apply "import ./extra/discover-env.nix \"<platform>\""
+#
+platform: jobs:
+let
+  envNames = builtins.filter
+    (n: builtins.match ".*-env" n != null)
+    (builtins.attrNames jobs);
+in map (name: {
+  config = platform + "." + name;
+  build_path = builtins.unsafeDiscardStringContext (toString jobs.${name});
+  short_name = name;
+}) envNames


### PR DESCRIPTION
## Summary
- When Hydra resolves builds from cache, it creates only aggregate `required` check-runs — not individual per-build check-runs like `x86_64-linux.ghc96-iog-env`
- This causes the GHA Discover step to find zero `-env` closures, producing an empty matrix and skipping all container uploads
- Add a fallback: when no Hydra check-runs are found, evaluate store paths directly from the flake using `nix eval` with `extra/discover-env.nix`
- Also install Nix and checkout the repo in the Discover step to support the fallback

## Context
After merging #239 and #240, the container upload workflows failed 3 consecutive times because Hydra completed all builds from cache without creating individual GitHub check-runs. This is the root cause of the upload failures on the current `main`.

## Test plan
- [ ] Verify the fallback `nix eval` produces the correct matrix (locally tested the Nix expression)
- [ ] Merge and confirm containers are uploaded on the next main push
- [ ] When Hydra does create individual check-runs (non-cached builds), the primary path is still used