### PR TITLE
ci: enable SSE for wait-for-hydra in PR validation

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -18,6 +18,7 @@ jobs:
     - uses: input-output-hk/actions/wait-for-hydra@latest
       with:
         check: required
+        hydra-status-url: https://ci.zw3rk.com
 
   discover:
     needs: wait-for-hydra


### PR DESCRIPTION
## Summary

- Enable SSE (Server-Sent Events) mode for `wait-for-hydra` in the PR validation workflow
- Connects to the hydra-github-bridge SSE endpoint at `https://ci.zw3rk.com` for real-time build status detection instead of polling the GitHub API
- Reduces wait time from minutes (poll interval with exponential backoff) to seconds (event-driven)

## Changes

One-line change: add `hydra-status-url: https://ci.zw3rk.com` to the wait-for-hydra step.

Without this input, the action falls back to the original GitHub API polling behavior.

## Test plan

- [x] Tested end-to-end in PR #241 — wait-for-hydra detected the `required` check via SSE, all 8 closure validations passed
- [x] SSE support merged to `input-output-hk/actions@latest` via [actions#41](https://github.com/input-output-hk/actions/pull/41)