### PR TITLE
Add gitMinimal to all shell environments

### DIFF
--- a/cross-js.nix
+++ b/cross-js.nix
@@ -104,6 +104,7 @@ pkgs.mkShell ({
         perl
         stdenv.cc.cc.lib
         which
+        gitMinimal
     ]) ++ (with pkgs.buildPackages; [
     ])
     ++ builtins.attrValues haskell-tools

--- a/cross-windows.nix
+++ b/cross-windows.nix
@@ -211,6 +211,7 @@ pkgs.pkgsBuildBuild.mkShell ({
         pkgsBuildBuild.perl
         stdenv.cc.cc.lib
         pkgsBuildBuild.which
+        pkgsBuildBuild.gitMinimal
     ])
     ++ map pkgs.lib.getDev (with pkgs; [
         zlib pcre openssl

--- a/dynamic.nix
+++ b/dynamic.nix
@@ -125,6 +125,7 @@ pkgs.mkShell {
         pcre
         pkg-config
         which
+        gitMinimal
         zlib
       ])
       ++ optional stdenv.hostPlatform.isLinux pkgs.systemd
@@ -135,7 +136,7 @@ pkgs.mkShell {
       )
       ++ attrValues haskell-tools
       ++ optionals withGHCTooling (
-        with pkgs; [ python3 automake autoconf alex happy git libffi.dev ]
+        with pkgs; [ python3 automake autoconf alex happy libffi.dev ]
       )
     ;
 

--- a/static.nix
+++ b/static.nix
@@ -161,6 +161,7 @@ pkgs.mkShell (rec {
         perl
         stdenv.cc.cc.lib
         which
+        gitMinimal
     ]) ++ (with pkgs.buildPackages; [
     ])
     ++ builtins.attrValues haskell-tools


### PR DESCRIPTION
## Summary

- Add `gitMinimal` to all 4 shell definitions (`dynamic.nix`, `static.nix`, `cross-js.nix`, `cross-windows.nix`) so `git` is available on PATH in every devx shell
- Replace the full `git` in `dynamic.nix`'s `withGHCTooling` block with the now-universal `gitMinimal`
- Fixes `Cabal-6666` ("The program 'git' is required but it could not be found") for projects using `source-repository-package` stanzas

## Motivation

[IntersectMBO/cardano-db-sync#2085](https://github.com/IntersectMBO/cardano-db-sync/pull/2085) has 6 failing CI jobs because Cabal cannot find `git` to fetch `source-repository-package` dependencies. The devx shells only included `git` in the `-ghc` (GHC tooling) variant — all other shells were missing it.

## Why `gitMinimal`

| | `gitMinimal` | `git` (default) |
|---|---|---|
| Closure size | **146 MiB** | **1.5 GiB** |
| Closure deps | 30 | 104 |
| Core git ops | All present | All present |

Nixpkgs itself uses `gitMinimal` for `fetchgit` — the identical use case. The 10x smaller closure matters for container images built from devx shells.

## Test plan

- [x] `nix eval` on `devShells` succeeds (no syntax/eval errors)
- [x] `nix develop .#ghc96-iog -c which git` → `/nix/store/...-git-minimal-2.51.2/bin/git`
- [ ] Hydra eval + env-test jobs pass