### PR TITLE
Update head.hackage hash

### DIFF
--- a/tool-map.nix
+++ b/tool-map.nix
@@ -15,7 +15,7 @@ let
              f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
              26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
              7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-          --sha256: sha256-yFGpWo9ulwBEUyzTLKJBtbCWi7Ly4NEtocBRogdew9g=
+          --sha256: sha256-O6vUr/LlMiC9FtmGQg+1DiiTnhkru8Bkgtrjo+A06gw=
 
         if impl(ghc < 9.13)
           active-repositories: hackage.haskell.org


### PR DESCRIPTION
This should fix the following error:

    error: hash mismatch in fixed-output derivation '/nix/store/4a81ynkkkxdg2zj29vf3nv9933n0ckxv-head.hackage.ghc.haskell.org.drv':
             specified: sha256-yFGpWo9ulwBEUyzTLKJBtbCWi7Ly4NEtocBRogdew9g=
                got:    sha256-O6vUr/LlMiC9FtmGQg+1DiiTnhkru8Bkgtrjo+A06gw=
    error: Cannot build '/nix/store/xa64sf0p9kxd57zbrn5jh4x6gnh7r22b-dot-cabal.drv'.