### PR TITLE
trim ghcXX-minimal-ghc closure: build happy/alex with the shell's GHC (−2.12 GB)

### DIFF
--- a/dynamic.nix
+++ b/dynamic.nix
@@ -135,7 +135,24 @@ pkgs.mkShell {
       )
       ++ attrValues haskell-tools
       ++ optionals withGHCTooling (
-        with pkgs; [ python3 automake autoconf alex happy git libffi.dev ]
+        # `pkgs.alex` and `pkgs.happy` from nixpkgs are built with a different
+        # GHC than the shell's `compiler` (currently ghc-9.10.3 in nixpkgs
+        # haskellPackages), and their library outputs anchor that foreign GHC
+        # in the closure (~2.15 GB on Darwin). Use haskell.nix's `tool` builder
+        # — same pattern as cross-js.nix and cross-windows.nix — to build them
+        # with the shell's `compiler-nix-name`, so library outputs reference
+        # the GHC that's already in the closure rather than dragging in a
+        # second one. `gitMinimal` swaps out heavyweight git (saves ~150 MB
+        # of perl-modules + git-doc that aren't used inside the shell).
+        with pkgs; [
+          python3
+          automake
+          autoconf
+          (tool "alex")
+          (tool "happy")
+          gitMinimal
+          libffi.dev
+        ]
       )
     ;
 

--- a/tool-map.nix
+++ b/tool-map.nix
@@ -43,8 +43,11 @@ compiler-nix-name: tool: {
       cabalProject = __readFile (src + "/cabal.project");
       configureArgs = "--disable-benchmarks --disable-tests";
   };
-  happy = { version = "1.20.1.1"; inherit cabalProjectLocal; };
-  alex = { version = "3.2.7.3"; inherit cabalProjectLocal; };
+  # happy/alex don't need head.hackage (they're standard mainline packages and
+  # build cleanly from regular hackage). Dropping `inherit cabalProjectLocal`
+  # also avoids depending on the head.hackage SHA pin going stale.
+  happy = { version = "2.1.7"; };
+  alex = { version = "3.5.4.0"; };
   cabal = rec {
     src = self.inputs.cabal;
     # We use the cabal.boostrap.project file, as we don't


### PR DESCRIPTION
## Summary

The `withGHCTooling = true` shells (`ghcXX-minimal-ghc`) source `happy` and `alex` from nixpkgs's `pkgs.haskellPackages`, which currently builds them with **ghc-9.10.3** — a different GHC than the shell's own `compiler`. The Haskell library outputs of both packages embed `lib/ghc-9.10.3/lib/*.dylib` path-strings; Nix's reference scanner anchors that *foreign* GHC into the closure even though nothing in the shell needs it at runtime.

On **aarch64-darwin** for `ghc98-minimal-ghc` this dragged in **ghc-9.10.3 (1.40 GB) + ghc-9.10.3-doc (753 MB)** — ~2.15 GB of essentially-unused payload.

## What this does

* `dynamic.nix`: switch `pkgs.alex` / `pkgs.happy` → `(tool "alex")` / `(tool "happy")` — same pattern `cross-js.nix` and `cross-windows.nix` already use. haskell.nix's `tool` builder uses the shell's `compiler-nix-name`, so the resulting library outputs reference the GHC that's *already in the closure*, not a foreign one.
* `dynamic.nix`: swap `git` → `gitMinimal` (drops perl-modules and git-doc that aren't useful inside the dev shell; ~150 MB cascade).
* `tool-map.nix`: drop `inherit cabalProjectLocal` from happy/alex. They're standard mainline packages and build cleanly from regular hackage. The inherited `cabalProjectLocal` pinned a head.hackage SHA that no longer matched and broke fresh evaluations of `(tool "happy")` / `(tool "alex")`. Versions bumped 1.20.1.1 → 2.1.7 (happy) and 3.2.7.3 → 3.5.4.0 (alex) to match what `pkgs.haskellPackages` was shipping previously — no behavioural change for users.

## Measured impact

| | `ghc98-minimal-ghc` on aarch64-darwin |
|---|--:|
| Closure size **before** | 6.12 GB (228 paths) |
| Closure size **after**  | **4.00 GB (196 paths)** |
| Saved | **−2.12 GB (−34.7 %)** |

Linux closure is unaffected by the happy/alex switch (Linux's `pkgs.haskellPackages.happy` was already not pulling a foreign GHC into the closure there), but `gitMinimal` saves a few tens of MB.

### Top paths removed

```
1399 MB  ghc-9.10.3
 753 MB  ghc-9.10.3-doc
  49 MB  git-2.51.2
  21 MB  alex-3.5.4.0 (pkgs.haskellPackages variant)
  18 MB  happy-2.1.7 (pkgs.haskellPackages variant)
  15 MB  git-2.51.2-doc
   9 MB  happy-lib-2.1.7
 (+ 6 perl-SSL modules from the gitMinimal cascade)
```

### Top paths added

```
46 MB  git-minimal-2.51.2
24 MB  alex-exe-alex-3.5.4.0     (haskell.nix-built with shell's GHC)
22 MB  happy-exe-happy-2.1.7      (same)
 ~2 MB  happy-lib-lib-*-2.1.7      (haskell.nix sub-libs)
```

## Verified

Inside the patched shell:

```
$ ghc --version    # 9.8.4
$ cabal --version  # 3.17.0.0
$ happy --version  # 2.1.7  (same as before)
$ alex --version   # 3.5.4.0 (same as before)
$ git --version    # 2.51.2 (now gitMinimal)
```

All tools resolve to expected store paths. The Hadrian build-hook (printed on `nix develop`) is unchanged.

## Why this matters

Downstream consumers caching the devx closure in CI (e.g. GitHub Actions, which has a 10 GB per-repo cache cap) gain ~2 GB of headroom on Darwin. This is the prerequisite for fitting bigger optional add-ons (e.g. a `ghcXX-minimal-ghc-web` flavor that bundles emscripten + wasi-sdk + node + wabt) into the cache without busting it.

## What's *not* in this PR

* **GHC `-doc` strip** (would save another 658 MB on Darwin). I prototyped `compiler.out` selection but it's a no-op — haskell.nix's GHC `out` output internally references its own `doc` sibling. Stripping the doc would need an upstream change to haskell.nix's compiler derivation. Deferred.
* **LLVM/clang static-link** (~378 MB on Darwin, would need a nixpkgs override).
* **Apple-SDK slim** (would need a different nixpkgs `apple-sdk` variant).

Happy to do follow-ups for any of these if there's interest.

## Test plan

- [x] `nix build .#devShells.aarch64-darwin.ghc98-minimal-ghc.inputDerivation` succeeds
- [x] `nix develop .#ghc98-minimal-ghc -c bash -c '…version checks…'` succeeds
- [x] Closure size measured before/after (`nix path-info -sS`)
- [ ] CI green
- [ ] Sanity check on x86_64-linux + aarch64-linux closures (expected: no regression, possibly small `gitMinimal` win)