### PR TITLE
add ghcXX-minimal-ghc-web flavor: wasm + JS backend dev tooling

### DIFF
--- a/dynamic.nix
+++ b/dynamic.nix
@@ -1,5 +1,5 @@
 # define a development shell for dynamically linked applications (default)
-{ self, pkgs, compiler, compiler-nix-name, toolsModule, withHLS ? true, withHlint ? true, withIOG ? true, withIOGFull ? false, withGHCTooling ? false }:
+{ self, pkgs, compiler, compiler-nix-name, toolsModule, withHLS ? true, withHlint ? true, withIOG ? true, withIOGFull ? false, withGHCTooling ? false, withWebTooling ? false }:
 let iog = import ./iog-libs.nix { inherit pkgs; };
     tool-version-map = (import ./tool-map.nix) self;
     tool = tool-name: pkgs.pkgsBuildBuild.haskell-nix.tool compiler-nix-name tool-name [(tool-version-map compiler-nix-name tool-name) toolsModule];
@@ -78,6 +78,7 @@ pkgs.mkShell {
                    + lib.optionalString withIOG                  "-iog"
                    + lib.optionalString withIOGFull              "-full"
                    + lib.optionalString withGHCTooling           "-ghc"
+                   + lib.optionalString withWebTooling           "-web"
                    ;
         in ''
         export PS1="\[\033[01;33m\][\w]$\[\033[00m\] "
@@ -152,6 +153,27 @@ pkgs.mkShell {
           (tool "happy")
           gitMinimal
           libffi.dev
+        ]
+      )
+      ++ optionals withWebTooling (
+        # Tooling for the wasm and JavaScript backends. wasi-sdk itself is
+        # deliberately not bundled — its version needs to match the
+        # wasm32-wasi-ghc cross-compiler bundle, which ghc-wasm-meta owns
+        # (https://gitlab.haskell.org/ghc/ghc-wasm-meta). Users still bootstrap
+        # wasi-sdk via ghc-wasm-meta's installer for wasm32-wasi cross-builds.
+        # What we DO bundle here:
+        #   * nodejs_22  — required for post-link.mjs (uses import.meta.filename
+        #                  added in Node 20.11; Ubuntu's apt nodejs is 18.x)
+        #                  and for JSFFI host execution
+        #   * wabt       — wasm-objdump for inspecting wasm modules
+        #   * wasmtime   — pure-WASI runtime (when no JSFFI imports)
+        #   * emscripten — the JavaScript backend's C toolchain (emcc / em++
+        #                  / emar / emnm / emranlib / emstrip)
+        with pkgs; [
+          nodejs_22
+          wabt
+          wasmtime
+          emscripten
         ]
       )
     ;

--- a/flake.nix
+++ b/flake.nix
@@ -226,6 +226,10 @@
                     import ./dynamic.nix (args // { withHLS = false; withHlint = false; withIOG = false; withGHCTooling = true; })
                   )) (compilers pkgs)
               // pkgs.lib.mapAttrs' (short-name: args:
+                  pkgs.lib.nameValuePair "${short-name}-minimal-ghc-web" (
+                    import ./dynamic.nix (args // { withHLS = false; withHlint = false; withIOG = false; withGHCTooling = true; withWebTooling = true; })
+                  )) (compilers pkgs)
+              // pkgs.lib.mapAttrs' (short-name: args:
                   pkgs.lib.nameValuePair "${short-name}-static" (
                     import ./static.nix (args // { withIOG = false; })
                   )) (compilers static-pkgs)


### PR DESCRIPTION
> **Stacked on top of #249.** This PR adds a flavor that enables wasm / JS-backend work; the parent PR trims the base closure so emscripten fits comfortably. Once #249 lands, this should rebase cleanly onto `main`.

## Summary

Adds `ghcXX-minimal-ghc-web` — `ghcXX-minimal-ghc` plus the dev-time tools the wasm + JavaScript backends need:

| Tool | Why |
|---|---|
| `nodejs_22` | `utils/jsffi/post-link.mjs` uses `import.meta.filename` (added in Node 20.11; Ubuntu apt nodejs is 18.x and silently breaks the post-link step); also for JSFFI host execution at test time |
| `wabt` | `wasm-objdump` for inspecting custom sections (e.g. detecting `ghc_wasm_jsffi` imports) |
| `wasmtime` | Pure-WASI runtime, when a wasm module has no JSFFI imports |
| `emscripten` | The JavaScript backend's C toolchain (`emcc` / `em++` / `emar` / `emnm` / `emranlib` / `emstrip`) |

Implementation is a single new `withWebTooling ? false` flag on `dynamic.nix`, an `optionals withWebTooling [...]` branch in `buildInputs`, and a new flake-output entry that wires `ghcXX-minimal-ghc-web` to the right `dynamic.nix` invocation. Suffix appended to the shellHook's flavor banner.

## Deliberately NOT bundled

**wasi-sdk.** Its version needs to match the `wasm32-wasi-ghc` cross-compiler bundle that [ghc-wasm-meta](https://gitlab.haskell.org/ghc/ghc-wasm-meta) owns. Bundling here would create two sources of truth for wasi-sdk pinning. Users still bootstrap wasi-sdk via ghc-wasm-meta for wasm32-wasi cross-builds.

## Measured closure (aarch64-darwin)

| Shell | Closure | Delta |
|---|--:|--:|
| `ghc98-minimal-ghc` (current `main`) | 6.12 GB | — |
| `ghc98-minimal-ghc` (with #249 trim) | 4.00 GB | −2.12 GB |
| **`ghc98-minimal-ghc-web` (this PR + #249)** | **5.99 GB** | **+1.99 GB over trim, −0.13 GB vs untrimmed `-minimal-ghc`** |

The web flavor (with the full toolchain incl. emscripten) ends up *slightly smaller than the current untrimmed `ghc98-minimal-ghc`* because:
* #249 removed the foreign ghc-9.10.3 (1.40 GB) and its doc (753 MB);
* emscripten's LLVM and apple-sdk dependencies now dedupe against the shell's base nixpkgs pin instead of pulling fragmented copies.

GitHub Actions per-repo cache cap is 10 GB; both flavors fit with significant headroom.

## What gets added vs the trimmed base

```
969 MB  emscripten-4.0.12
387 MB  emscripten-node-modules-4.0.12
341 MB  zulu-ca-jdk-21.0.8        (for closure-compiler)
 75 MB  nodejs-22.21.1
 53 MB  nodejs-22.21.1-dev
 43 MB  wasmtime-38.0.3
 37 MB  icu4c-76.1
 32 MB  binaryen-124
 32 MB  lld-21.1.2
 30 MB  wasmtime-38.0.3-lib
  ~13 MB  (sqlite, llvm-bin, ports, support)
─────
1.99 GB total delta (22 paths)
```

## Verified

```
$ ghc --version            # 9.8.4
$ cabal --version          # 3.17.0.0
$ happy --version          # 2.1.7
$ alex --version           # 3.5.4.0
$ git --version            # 2.51.2 (gitMinimal from #249)
$ node --version           # v22.21.1
$ wasm-objdump --version   # 1.0.37
$ wasmtime --version       # 38.0.3
$ emcc --version           # 4.0.12-git
```

All resolve to expected store paths.

## Downstream impact

This collapses ~70 lines of platform-shell (apt + NodeSource + curl + nix-env + PATH workarounds) in stable-haskell/ghc's wasm CI to a single `shell: devx-ghcXX-minimal-ghc-web` line. Other consumers building wasm or JS-backend Haskell projects get the same simplification.

## Test plan

- [x] `nix build .#devShells.aarch64-darwin.ghc98-minimal-ghc-web.inputDerivation`
- [x] `nix develop .#ghc98-minimal-ghc-web -c bash -c '…version checks…'`
- [x] Closure measured (5.99 GB on Darwin)
- [ ] CI green
- [ ] Verify on x86_64-linux + aarch64-linux (expected smaller than Darwin, no apple-sdk)
- [ ] Sanity-build a wasm hello world in the shell